### PR TITLE
Drop runtime dependency on setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development
     Topic :: Utilities
 keywords =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ keywords =
 packages = find:
 install_requires =
     arrow
-    setuptools
+    importlib-metadata;python_version<"3.8"
     rpm
 python_requires = >=3.6
 include_package_data = True

--- a/specfile/__init__.py
+++ b/specfile/__init__.py
@@ -5,11 +5,15 @@
 A library for parsing and manipulating RPM spec files
 """
 
-from pkg_resources import DistributionNotFound, get_distribution
+try:
+    from importlib.metadata import PackageNotFoundError, distribution
+except ImportError:
+    from importlib_metadata import PackageNotFoundError  # type: ignore
+    from importlib_metadata import distribution  # type: ignore
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = distribution(__name__).version
+except PackageNotFoundError:
     # package is not installed
     pass
 


### PR DESCRIPTION
The setuptools package is a huge overkill to get self-version.

Use the standard library instead on Python 3.8+,
or a smaller package on older Pythons.

Declare support for new Pythons (extra commit).