### PR TITLE
pre-commit updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/psf/black
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.0
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -44,7 +44,7 @@ repos:
       - id: isort
         args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.941
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/files/install-requirements-pip.yaml
+++ b/files/install-requirements-pip.yaml
@@ -9,4 +9,5 @@
       with_items:
         - arrow
         - rpm-py-installer
+        - typing-extensions
       become: true

--- a/files/tasks/rpm-deps.yaml
+++ b/files/tasks/rpm-deps.yaml
@@ -3,4 +3,5 @@
   dnf:
     name:
       - python3-arrow
+      - python3-typing-extensions
   become: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     arrow
     importlib-metadata;python_version<"3.8"
     rpm
+    typing-extensions
 python_requires = >=3.6
 include_package_data = True
 setup_requires =

--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -5,6 +5,8 @@ import collections
 import re
 from typing import List, Optional, overload
 
+from typing_extensions import SupportsIndex
+
 # valid section names as defined in build/parseSpec.c in RPM source
 SECTION_NAMES = {
     "package",
@@ -79,7 +81,7 @@ class Section(collections.UserList):
         return Section(self.name, self.data)
 
     @overload
-    def __getitem__(self, i: int) -> str:
+    def __getitem__(self, i: SupportsIndex) -> str:
         pass
 
     @overload

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -5,6 +5,8 @@ import collections
 import re
 from typing import Any, Iterable, List, Optional, Union, overload
 
+from typing_extensions import SupportsIndex
+
 from specfile.sections import Section
 
 # valid tag names extracted from lib/rpmtag.h in RPM source
@@ -334,7 +336,7 @@ class Comments(collections.UserList):
         return item in self.data
 
     @overload
-    def __getitem__(self, i: int) -> Comment:
+    def __getitem__(self, i: SupportsIndex) -> Comment:
         pass
 
     @overload
@@ -348,7 +350,7 @@ class Comments(collections.UserList):
             return self.data[i]
 
     @overload
-    def __setitem__(self, i: int, item: Union[Comment, str]) -> None:
+    def __setitem__(self, i: SupportsIndex, item: Union[Comment, str]) -> None:
         pass
 
     @overload
@@ -523,7 +525,7 @@ class Tags(collections.UserList):
         return f"Tags({data}, {remainder})"
 
     @overload
-    def __getitem__(self, i: int) -> Tag:
+    def __getitem__(self, i: SupportsIndex) -> Tag:
         pass
 
     @overload


### PR DESCRIPTION
This includes changes from #21, making it obsolete.

See https://github.com/python/typeshed/commit/98af7d667fa668dec9dc640f0f2669c6e3453e86 for context.