### PR TITLE
Configure Packit for the python-specfile package

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,82 @@
+---
+specfile_path: fedora/python-specfile.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - fedora/python-specfile.spec
+  - .packit.yaml
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: specfile
+# downstream (Fedora) RPM package name
+downstream_package_name: python-specfile
+
+copy_upstream_release_description: true
+
+actions:
+  # we need this b/c `git archive` doesn't put all the metadata in the tarball:
+  #   LookupError: setuptools-scm was unable to detect version for '/builddir/build/BUILD/ogr-0.11.1'.
+  #   Make sure you're either building from a fully intact git repository or PyPI tarballs.
+  create-archive:
+    - python3 setup.py sdist --dist-dir ./fedora/
+    - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
+  get-current-version: python3 setup.py --version
+
+srpm_build_deps:
+  - python3-pip # "python3 setup.py --version" needs it
+  - python3-setuptools_scm
+
+jobs:
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist_git_branches:
+        - fedora-all
+        - epel-8
+
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-all
+        - epel-8
+  - job: tests
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-all
+        - epel-8
+
+  - job: copr_build
+    trigger: commit
+    metadata:
+      branch: main
+      targets:
+        - fedora-all
+        - epel-8
+      project: packit-dev
+      list_on_homepage: True
+      preserve_project: True
+  - job: copr_build
+    trigger: release
+    metadata:
+      targets:
+        - fedora-all
+        - epel-8
+      project: packit-releases
+      list_on_homepage: True
+      preserve_project: True
+
+  # downstream automation:
+  - job: koji_build
+    trigger: commit
+    metadata:
+      dist_git_branches:
+        - fedora-all
+        - epel-8
+  - job: bodhi_update
+    trigger: commit
+    metadata:
+      dist_git_branches:
+        - fedora-stable # rawhide updates are created automatically
+        - epel-8

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,19 +32,34 @@ jobs:
     metadata:
       dist_git_branches:
         - fedora-all
+  - job: propose_downstream
+    trigger: release
+    specfile_path: epel/python-specfile.spec
+    files_to_sync:
+      - epel/python-specfile.spec
+      - .packit.yaml
+    metadata:
+      dist_git_branches:
         - epel-8
 
   - job: copr_build
     trigger: pull_request
+    identifier: fedora
     metadata:
       targets:
         - fedora-all
-        - epel-8
-  - job: tests
+  - &copr_build_pr_epel
+    job: copr_build
     trigger: pull_request
+    specfile_path: epel/python-specfile.spec
+    identifier: epel
+    actions:
+      create-archive:
+        - python3 setup.py sdist --dist-dir ./epel/
+        - bash -c "ls -1t ./epel/*.tar.gz | head -n 1"
+      get-current-version: python3 setup.py --version
     metadata:
       targets:
-        - fedora-all
         - epel-8
 
   - job: copr_build
@@ -53,15 +68,31 @@ jobs:
       branch: main
       targets:
         - fedora-all
+      project: packit-dev
+      list_on_homepage: True
+      preserve_project: True
+  - <<: *copr_build_pr_epel
+    trigger: commit
+    metadata:
+      branch: main
+      targets:
         - epel-8
       project: packit-dev
       list_on_homepage: True
       preserve_project: True
+
   - job: copr_build
     trigger: release
     metadata:
       targets:
         - fedora-all
+      project: packit-releases
+      list_on_homepage: True
+      preserve_project: True
+  - <<: *copr_build_pr_epel
+    trigger: release
+    metadata:
+      targets:
         - epel-8
       project: packit-releases
       list_on_homepage: True

--- a/epel/python-specfile.spec
+++ b/epel/python-specfile.spec
@@ -1,0 +1,64 @@
+%global desc %{expand:
+Python library for parsing and manipulating RPM spec files.
+Main focus is on modifying existing spec files, any change should result
+in a minimal diff.}
+
+
+Name:           python-specfile
+Version:        0.1.1
+Release:        1%{?dist}
+
+Summary:        A library for parsing and manipulating RPM spec files
+License:        MIT
+URL:            https://github.com/packit/specfile
+
+Source0:        https://github.com/packit/specfile/archive/%{version}/specfile-%{version}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+
+
+%description
+%{desc}
+
+
+%package -n python%{python3_pkgversion}-specfile
+Summary:        %{summary}
+
+
+%description -n python%{python3_pkgversion}-specfile
+%{desc}
+
+
+%generate_buildrequires
+%pyproject_buildrequires -x testing
+
+
+%prep
+%autosetup -p1 -n specfile-%{version}
+
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files specfile
+
+
+%check
+%pytest
+
+
+%files -n python%{python3_pkgversion}-specfile -f %{pyproject_files}
+%doc README.md
+
+
+%changelog
+* Mon Feb 21 2022 Nikola Forró <nforro@redhat.com> - 0.1.1-1
+- New upstream release 0.1.1
+
+* Tue Feb 08 2022 Nikola Forró <nforro@redhat.com> - 0.1.0-1
+- Initial package


### PR DESCRIPTION
There are multiple jobs configured:

* `propose_downstream` for release => will submit pull-requests for a new GitHub release.
* `copr_build` for PR => will trigger the Copr build for pull-requests.
* `copr_build` for `main` branch commits and releases => Will built in the Packit's Copr projects
  where other projects like `python-ogr` and `packit` are built.
* `koji_build` for new dist-git commits for all Fedora branches and `epel-8`.
* `bodhi_update` for successful builds for all stable Fedora branches and `epel-8`.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>