### PR TITLE
Update spec files

### DIFF
--- a/epel/python-specfile.spec
+++ b/epel/python-specfile.spec
@@ -17,6 +17,9 @@ Source0:        %{pypi_source specfile}
 BuildArch:      noarch
 
 BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  %{py3_dist setuptools setuptools-scm setuptools-scm-git-archive}
+BuildRequires:  %{py3_dist arrow importlib-metadata rpm typing-extensions}
+BuildRequires:  %{py3_dist flexmock pytest}
 
 
 %description
@@ -31,29 +34,29 @@ Summary:        %{summary}
 %{desc}
 
 
-%generate_buildrequires
-%pyproject_buildrequires -x testing
-
-
 %prep
 %autosetup -p1 -n specfile-%{version}
+# Remove bundled egg-info
+rm -rf specfile.egg-info
 
 
 %build
-%pyproject_wheel
+%py3_build
 
 
 %install
-%pyproject_install
-%pyproject_save_files specfile
+%py3_install
 
 
 %check
 %pytest
 
 
-%files -n python%{python3_pkgversion}-specfile -f %{pyproject_files}
+%files -n python%{python3_pkgversion}-specfile
+%license LICENSE
 %doc README.md
+%{python3_sitelib}/specfile
+%{python3_sitelib}/specfile-%{version}-py%{python3_version}.egg-info
 
 
 %changelog

--- a/epel/python-specfile.spec
+++ b/epel/python-specfile.spec
@@ -12,7 +12,7 @@ Summary:        A library for parsing and manipulating RPM spec files
 License:        MIT
 URL:            https://github.com/packit/specfile
 
-Source0:        https://github.com/packit/specfile/archive/%{version}/specfile-%{version}.tar.gz
+Source0:        %{pypi_source specfile}
 
 BuildArch:      noarch
 

--- a/fedora/python-specfile.spec
+++ b/fedora/python-specfile.spec
@@ -12,7 +12,7 @@ Summary:        A library for parsing and manipulating RPM spec files
 License:        MIT
 URL:            https://github.com/packit/specfile
 
-Source0:        https://github.com/packit/specfile/archive/%{version}/specfile-%{version}.tar.gz
+Source0:        %{pypi_source specfile}
 
 BuildArch:      noarch
 


### PR DESCRIPTION
This is a follow-up to #25.

The EPEL spec file should be correct now, however the build on EPEL fails because of multiple issues, namely:
* missing `tmp_path` fixture (already solved in [packit](https://github.com/packit/packit/blob/070792da802b32d29ce527838fe1c0c1137f5c79/tests/conftest.py#L28-L39))
* infinite loop in `Macros.remove()` (fixed in https://github.com/packit/specfile/commit/e3d3022b8781b104bc6b18aa770f43fe1e1d8476)
* older version of `arrow` inability to parse changelog entry headers (needs investigation)