### PR TITLE
Use upstream for creating issues about downstream Packit failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,9 @@ downstream_package_name: python-specfile
 
 copy_upstream_release_description: true
 
+upstream_project_url: https://github.com/packit/specfile
+issue_repository: https://github.com/packit/specfile
+
 actions:
   # we need this b/c `git archive` doesn't put all the metadata in the tarball:
   #   LookupError: setuptools-scm was unable to detect version for '/builddir/build/BUILD/ogr-0.11.1'.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,11 @@ repos:
     hooks:
       - id: pyupgrade
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0
+    rev: v2.6.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -44,7 +44,7 @@ repos:
       - id: isort
         args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.941
+    rev: v0.942
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]


### PR DESCRIPTION
Use upstream for creating issues about downstream Packit failures

See https://packit.dev/docs/configuration/#issue_repository