### PR TITLE
Enhance sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ with specfile.patches() as patches:
     # adding and removing patches
     patches.append('another.patch')
     del patches[2]
+    # inserting a patch with a specific number
+    patches.insert_numbered(999, 'final.patch')
 
 # fetching non-local sources (including patches)
 specfile.download_remote_sources()

--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -192,7 +192,11 @@ class Sources(collections.abc.MutableSequence):
     PREFIX: str = "Source"
 
     def __init__(
-        self, tags: Tags, sourcelists: List[Sourcelist], allow_duplicates: bool = False
+        self,
+        tags: Tags,
+        sourcelists: List[Sourcelist],
+        allow_duplicates: bool = False,
+        default_source_number_digits: int = 1,
     ) -> None:
         """
         Constructs a `Sources` object.
@@ -201,6 +205,7 @@ class Sources(collections.abc.MutableSequence):
             tags: All spec file tags.
             sourcelists: List of all %sourcelist sections.
             allow_duplicates: Whether to allow duplicate entries when adding new sources.
+            default_source_number_digits: Default number of digits in a source number.
 
         Returns:
             Constructed instance of `Sources` class.
@@ -208,6 +213,7 @@ class Sources(collections.abc.MutableSequence):
         self._tags = tags
         self._sourcelists = sourcelists
         self._allow_duplicates = allow_duplicates
+        self._default_source_number_digits = default_source_number_digits
 
     def __repr__(self) -> str:
         tags = repr(self._tags)
@@ -215,7 +221,10 @@ class Sources(collections.abc.MutableSequence):
         allow_duplicates = repr(self._allow_duplicates)
         # determine class name dynamically so that inherited classes
         # don't have to reimplement __repr__()
-        return f"{self.__class__.__name__}({tags}, {sourcelists}, {allow_duplicates})"
+        return (
+            f"{self.__class__.__name__}({tags}, {sourcelists}, {allow_duplicates}, "
+            f"{self._default_source_number_digits})"
+        )
 
     def __contains__(self, location: object) -> bool:
         items = self._get_items()
@@ -338,7 +347,8 @@ class Sources(collections.abc.MutableSequence):
             Tuple in the form of (index, name, separator).
         """
         prefix = self.PREFIX.capitalize()
-        return len(self._tags) if self._tags else 0, f"{prefix}{number}", ": "
+        suffix = f"{number:0{self._default_source_number_digits}}"
+        return len(self._tags) if self._tags else 0, f"{prefix}{suffix}", ": "
 
     def _deduplicate_tag_names(self) -> None:
         """Eliminates duplicate numbers in source tag names."""

--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -21,42 +21,42 @@ class Source(ABC):
     @abstractmethod
     def number(self) -> int:
         """Source number."""
-        pass
+        ...
 
     @property  # type: ignore
     @abstractmethod
     def location(self) -> str:
         """Literal location of the source as stored in the spec file."""
-        pass
+        ...
 
     @location.setter  # type: ignore
     @abstractmethod
     def location(self, value: str) -> None:
-        pass
+        ...
 
     @property  # type: ignore
     @abstractmethod
     def expanded_location(self) -> str:
         """Location of the source after expanding macros."""
-        pass
+        ...
 
     @property  # type: ignore
     @abstractmethod
     def filename(self) -> str:
         """Literal filename of the source."""
-        pass
+        ...
 
     @property  # type: ignore
     @abstractmethod
     def expanded_filename(self) -> str:
         """Filename of the source after expanding macros."""
-        pass
+        ...
 
     @property  # type: ignore
     @abstractmethod
     def comments(self) -> Comments:
         """List of comments associated with the source."""
-        pass
+        ...
 
 
 class TagSource(Source):

--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -189,7 +189,7 @@ class ListSource(Source):
 class Sources(collections.abc.MutableSequence):
     """Class that represents a sequence of all sources."""
 
-    PREFIX = "Source"
+    PREFIX: str = "Source"
 
     def __init__(
         self, tags: Tags, sourcelists: List[Sourcelist], allow_duplicates: bool = False
@@ -420,7 +420,7 @@ class Sources(collections.abc.MutableSequence):
 class Patches(Sources):
     """Class that represents a sequence of all patches."""
 
-    PREFIX = "Patch"
+    PREFIX: str = "Patch"
 
     def _get_initial_tag_setup(self) -> Tuple[int, str, str]:
         """

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -156,12 +156,15 @@ class Specfile:
                 yield Prep(section)
 
     @contextlib.contextmanager
-    def sources(self, allow_duplicates: bool = False) -> Iterator[Sources]:
+    def sources(
+        self, allow_duplicates: bool = False, default_source_number_digits: int = 1
+    ) -> Iterator[Sources]:
         """
         Context manager for accessing sources.
 
         Args:
             allow_duplicates: Whether to allow duplicate entries when adding new sources.
+            default_source_number_digits: Default number of digits in a source number.
 
         Yields:
             Spec file sources as `Sources` object.
@@ -175,18 +178,22 @@ class Specfile:
                     tags,
                     list(zip(*sourcelists))[1] if sourcelists else [],
                     allow_duplicates,
+                    default_source_number_digits,
                 )
             finally:
                 for section, sourcelist in sourcelists:
                     section.data = sourcelist.get_raw_section_data()
 
     @contextlib.contextmanager
-    def patches(self, allow_duplicates: bool = False) -> Iterator[Patches]:
+    def patches(
+        self, allow_duplicates: bool = False, default_source_number_digits: int = 1
+    ) -> Iterator[Patches]:
         """
         Context manager for accessing patches.
 
         Args:
             allow_duplicates: Whether to allow duplicate entries when adding new patches.
+            default_source_number_digits: Default number of digits in a source number.
 
         Yields:
             Spec file patches as `Patches` object.
@@ -200,6 +207,7 @@ class Specfile:
                     tags,
                     list(zip(*patchlists))[1] if patchlists else [],
                     allow_duplicates,
+                    default_source_number_digits,
                 )
             finally:
                 for section, patchlist in patchlists:

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -76,7 +76,7 @@ def test_patches(spec_patchlist):
     with spec.patches() as patches:
         patches.insert(0, patch)
         assert patches[0].location == patch
-        assert patches[1].index == 1
+        assert patches[1].number == 1
     with spec.tags() as tags:
         assert len([t for t in tags if t.name.startswith("Patch")]) == 2
     with spec.patches() as patches:

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -11,7 +11,7 @@ from specfile.tags import Comments, Tag, Tags
 
 
 @pytest.mark.parametrize(
-    "tag_name, index",
+    "tag_name, number",
     [
         ("Source", None),
         ("Source0", "0"),
@@ -20,22 +20,22 @@ from specfile.tags import Comments, Tag, Tags
         ("Patch99999", "99999"),
     ],
 )
-def test_tag_source_get_index(tag_name, index):
+def test_tag_source_get_number(tag_name, number):
     ts = TagSource(Tag(tag_name, "", "", "", Comments()))
-    assert ts._get_index() == index
+    assert ts._get_number() == number
 
 
 @pytest.mark.parametrize(
-    "ref_name, ref_separator, index, name, separator",
+    "ref_name, ref_separator, number, name, separator",
     [
         ("Source", ": ", 28, "Source28", ":"),
         ("Source0001", ":      ", 2, "Source0002", ":      "),
     ],
 )
-def test_sources_get_tag_format(ref_name, ref_separator, index, name, separator):
+def test_sources_get_tag_format(ref_name, ref_separator, number, name, separator):
     sources = Sources(None, [])
     reference = TagSource(Tag(ref_name, "", "", ref_separator, Comments()))
-    assert sources._get_tag_format(reference, index) == (name, separator)
+    assert sources._get_tag_format(reference, number) == (name, separator)
 
 
 @pytest.mark.parametrize(
@@ -72,7 +72,7 @@ def test_sources_deduplicate_tag_names(tags, deduplicated_tags):
 
 
 @pytest.mark.parametrize(
-    "tags, sourcelists, index, location, source_index, cls",
+    "tags, sourcelists, index, location, number, cls",
     [
         ([("Name", "test"), ("Version", "0.1")], [], 0, "test", 0, TagSource),
         ([("Name", "test"), ("Version", "0.1")], [[]], 0, "test", 0, ListSource),
@@ -151,7 +151,7 @@ def test_sources_deduplicate_tag_names(tags, deduplicated_tags):
         ),
     ],
 )
-def test_sources_insert(tags, sourcelists, index, location, source_index, cls):
+def test_sources_insert(tags, sourcelists, index, location, number, cls):
     sources = Sources(
         Tags([Tag(t, v, v, ": ", Comments()) for t, v in tags]),
         [
@@ -169,22 +169,22 @@ def test_sources_insert(tags, sourcelists, index, location, source_index, cls):
         if index >= len(sources):
             index = len(sources) - 1
         assert isinstance(sources[index], cls)
-        assert sources[index].index == source_index
+        assert sources[index].number == number
         assert sources[index].location == location
 
 
 @pytest.mark.parametrize(
-    "ref_name, ref_separator, index, name, separator",
+    "ref_name, ref_separator, number, name, separator",
     [
         ("Patch99", ":      ", 100, "Patch100", ":     "),
         ("Patch9999", ":  ", 28, "Patch0028", ":  "),
         ("Source2", ":     ", 0, "Patch0", ":      "),
     ],
 )
-def test_patches_get_tag_format(ref_name, ref_separator, index, name, separator):
+def test_patches_get_tag_format(ref_name, ref_separator, number, name, separator):
     patches = Patches(None, [])
     reference = TagSource(Tag(ref_name, "", "", ref_separator, Comments()))
-    assert patches._get_tag_format(reference, index) == (name, separator)
+    assert patches._get_tag_format(reference, number) == (name, separator)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Firstly, this PR introduces the term "source number" in place of "source index" (or just "index"), which is ambiguous. This should make both the code and the API more clear.

It also adds, among some minor improvements, a functionality that will be needed for packit integration.