### PR TITLE
Unify packit stg and prod usage

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,4 +1,9 @@
 ---
+# We want to use both instances for all upstream jobs including the `propose-downstream` one.
+# For downstream, we need to pick just one instance (`stg` in our case)
+# and redefine it for the `koji_build` and `bodhi_update` jobs.
+packit_instances: ["prod", "stg"]
+
 specfile_path: fedora/python-specfile.spec
 
 # add or remove files that should be synced
@@ -104,12 +109,14 @@ jobs:
   # downstream automation:
   - job: koji_build
     trigger: commit
+    packit_instances: ["stg"]
     metadata:
       dist_git_branches:
         - fedora-all
         - epel-8
   - job: bodhi_update
     trigger: commit
+    packit_instances: ["stg"]
     metadata:
       dist_git_branches:
         - fedora-stable # rawhide updates are created automatically

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -119,5 +119,5 @@ jobs:
     packit_instances: ["stg"]
     metadata:
       dist_git_branches:
-        - fedora-stable # rawhide updates are created automatically
+        - fedora-branched # rawhide updates are created automatically
         - epel-8


### PR DESCRIPTION
* We want to use both instances for all upstream jobs including the `propose-downstream` one.
For downstream, we need to pick just one instance (`stg` in our case)
and redefine it for the `koji_build` and `bodhi_update` jobs.
* [Use the correct alias for creating Bodhi updates](https://github.com/packit/specfile/commit/c91ab072f195e3e160b51e35f4ccc1b00608603b)
  * https://packit.dev/docs/configuration/#aliases: fedora-branched — all branched releases, that is: everything, except Rawhide (e.g. fedora-34, fedora-35, fedora-36).