### PR TITLE
Enforce strict optional typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,7 @@ repos:
     rev: v0.960
     hooks:
       - id: mypy
-        args:
-          [--show-error-codes, --no-strict-optional, --ignore-missing-imports]
+        args: [--show-error-codes, --ignore-missing-imports]
         additional_dependencies:
           [types-pkg_resources, types-requests, types-python-dateutil]
   - repo: https://github.com/packit/pre-commit-hooks

--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -190,7 +190,7 @@ class Sections(collections.UserList):
                     if r.match(line):
                         section_starts.append(i)
                         break
-        section_starts.append(None)
+        section_starts.append(len(lines))
         data = [Section(PREAMBLE, lines[: section_starts[0]])]
         for start, end in zip(section_starts, section_starts[1:]):
             data.append(Section(lines[start][1:], lines[start + 1 : end]))


### PR DESCRIPTION
Using --no-strict-optional allows invalid handling of None types, e.g.
binding an Optional type to a non-Optional and much more. Update the
codebase to remove this option.

Related: https://github.com/packit/packit-service/issues/1433