### PR TITLE
Accept any number of whitespaces when parsing %changelog entry timestamp

### DIFF
--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -55,7 +55,10 @@ class ChangelogEntry:
     def extended_timestamp(self) -> bool:
         """Whether the timestamp present in the entry header is extended (date and time)."""
         try:
-            arrow.get(self.header, ["ddd MMM D YYYY", "ddd MMM DD YYYY"])
+            arrow.get(
+                self.header,
+                [r"ddd[\s+]MMM[\s+]D[\s+]YYYY", r"ddd[\s+]MMM[\s+]DD[\s+]YYYY"],
+            )
         except arrow.parser.ParserError:
             return True
         else:

--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -57,12 +57,15 @@ class ChangelogEntry:
         try:
             arrow.get(
                 self.header,
-                [r"ddd[\s+]MMM[\s+]D[\s+]YYYY", r"ddd[\s+]MMM[\s+]DD[\s+]YYYY"],
+                [
+                    r"ddd[\s+]MMM[\s+]D[\s+]HH:mm:ss[\s+][\w+][\s+]YYYY",
+                    r"ddd[\s+]MMM[\s+]DD[\s+]HH:mm:ss[\s+][\w+][\s+]YYYY",
+                ],
             )
         except arrow.parser.ParserError:
-            return True
-        else:
             return False
+        else:
+            return True
 
     @staticmethod
     def assemble(

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -14,6 +14,7 @@ from specfile.sections import Section
     "header, extended",
     [
         ("* Tue May 4 2021 Nikola Forró <nforro@redhat.com> - 0.1-1", False),
+        ("* Tue May  4 2021 Nikola Forró <nforro@redhat.com> - 0.1-1", False),
         (
             "* Thu Jul 22 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.1-2",
             False,


### PR DESCRIPTION
Fixes #80.