### PR TITLE
Fix requires of EPEL rpm

### DIFF
--- a/epel/python-specfile.spec
+++ b/epel/python-specfile.spec
@@ -36,6 +36,8 @@ Summary:        %{summary}
 
 %prep
 %autosetup -p1 -n specfile-%{version}
+# Use packaged RPM python bindings downstream
+sed -i 's/rpm-py-installer/rpm/' setup.cfg
 # Remove bundled egg-info
 rm -rf specfile.egg-info
 


### PR DESCRIPTION
`rpmbuild` on EPEL doesn't support dynamic buildrequires, but runtime requires are still generated from `setup.cfg`, so `rpm-py-installer` has to be substituted with `rpm`.