### PR TITLE
Avoid using arrow for working with changelog timestamps

### DIFF
--- a/epel/python-specfile.spec
+++ b/epel/python-specfile.spec
@@ -18,7 +18,7 @@ BuildArch:      noarch
 
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  %{py3_dist setuptools setuptools-scm setuptools-scm-git-archive}
-BuildRequires:  %{py3_dist arrow importlib-metadata rpm typing-extensions}
+BuildRequires:  %{py3_dist importlib-metadata rpm typing-extensions}
 BuildRequires:  %{py3_dist flexmock pytest}
 
 

--- a/files/install-requirements-pip.yaml
+++ b/files/install-requirements-pip.yaml
@@ -7,7 +7,6 @@
       pip:
         name: "{{ item }}"
       with_items:
-        - arrow
         - rpm-py-installer
         - typing-extensions
       become: true

--- a/files/tasks/rpm-deps.yaml
+++ b/files/tasks/rpm-deps.yaml
@@ -2,6 +2,5 @@
 - name: Install runtime RPM dependencies
   dnf:
     name:
-      - python3-arrow
       - python3-typing-extensions
   become: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ keywords =
 [options]
 packages = find:
 install_requires =
-    arrow
     importlib-metadata;python_version<"3.8"
     rpm-py-installer
     typing-extensions

--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -94,6 +94,27 @@ class ChangelogEntry:
         )
         return m is not None
 
+    @property
+    def day_of_month_padding(self) -> str:
+        """Padding of day of month in the entry header timestamp"""
+        weekdays = "|".join(WEEKDAYS)
+        months = "|".join(MONTHS)
+        m = re.search(
+            rf"""
+            ({weekdays})                 # weekday
+            [ ]
+            ({months})                   # month
+            [ ]
+            (?P<wsp>[ ]*)                # optional whitespace padding
+            ((?P<zp>0)?\d|[12]\d|3[01])  # possibly zero-padded day of month
+            """,
+            self.header,
+            re.VERBOSE,
+        )
+        if not m:
+            return ""
+        return m.group("wsp") + (m.group("zp") or "")
+
     @staticmethod
     def assemble(
         timestamp: Union[datetime.date, datetime.datetime],

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -281,9 +281,21 @@ class Specfile:
                     raise SpecfileException("Failed to auto-detect author") from e
             elif email is not None:
                 author += f" <{email}>"
+            if changelog:
+                # try to preserve padding of day of month
+                padding = max(
+                    (e.day_of_month_padding for e in reversed(changelog)), key=len
+                )
+            else:
+                padding = "0"
             changelog.append(
                 ChangelogEntry.assemble(
-                    timestamp, author, entry, evr, append_newline=bool(changelog)
+                    timestamp,
+                    author,
+                    entry,
+                    evr,
+                    day_of_month_padding=padding,
+                    append_newline=bool(changelog),
                 )
             )
 

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -9,8 +9,6 @@ import types
 from pathlib import Path
 from typing import Iterator, List, Optional, Tuple, Type, Union
 
-import arrow
-
 from specfile.changelog import Changelog, ChangelogEntry
 from specfile.exceptions import SourceNumberException, SpecfileException
 from specfile.prep import Prep
@@ -271,12 +269,11 @@ class Specfile:
             if isinstance(entry, str):
                 entry = [entry]
             if timestamp is None:
-                now = arrow.now()
                 # honor the timestamp format, but default to date-only
                 if changelog and changelog[-1].extended_timestamp:
-                    timestamp = now.datetime
+                    timestamp = datetime.datetime.now().astimezone()
                 else:
-                    timestamp = now.date()
+                    timestamp = datetime.date.today()
             if author is None:
                 try:
                     author = subprocess.check_output("rpmdev-packager").decode().strip()

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -29,6 +29,26 @@ def test_entry_has_extended_timestamp(header, extended):
     assert ChangelogEntry(header, [""]).extended_timestamp == extended
 
 
+@pytest.mark.parametrize(
+    "header, padding",
+    [
+        ("* Tue May 4 2021 Nikola Forró <nforro@redhat.com> - 0.1-1", ""),
+        ("* Tue May 04 2021 Nikola Forró <nforro@redhat.com> - 0.1-1", "0"),
+        ("* Tue May  4 2021 Nikola Forró <nforro@redhat.com> - 0.1-1", " "),
+        (
+            "* Thu Jul 22 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.1-2",
+            "",
+        ),
+        (
+            "* Mon Oct  18 12:34:45 CEST 2021 Nikola Forró <nforro@redhat.com> - 0.2-1",
+            " ",
+        ),
+    ],
+)
+def test_entry_day_of_month_padding(header, padding):
+    assert ChangelogEntry(header, [""]).day_of_month_padding == padding
+
+
 def test_parse():
     changelog = Changelog.parse(
         Section(

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -3,7 +3,6 @@
 
 import datetime
 
-import dateutil.tz
 import pytest
 
 from specfile.changelog import Changelog, ChangelogEntry
@@ -99,6 +98,7 @@ def test_parse():
 
 
 def test_get_raw_section_data():
+    tzinfo = datetime.timezone(datetime.timedelta(hours=2), name="CEST")
     changelog = Changelog(
         [
             ChangelogEntry.assemble(
@@ -115,9 +115,7 @@ def test_get_raw_section_data():
                 "0.1-2",
             ),
             ChangelogEntry.assemble(
-                datetime.datetime(
-                    2021, 10, 18, 12, 34, 45, tzinfo=dateutil.tz.gettz("CET")
-                ),
+                datetime.datetime(2021, 10, 18, 12, 34, 45, tzinfo=tzinfo),
                 "Nikola Forró <nforro@redhat.com>",
                 ["- new upstream release"],
                 "0.2-1",


### PR DESCRIPTION
This makes it easier to build specfile for EPEL 9.

Fixes #78.