### PR TITLE
Specify allowed_pr_authors in Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -119,6 +119,7 @@ jobs:
   - job: koji_build
     trigger: commit
     packit_instances: ["stg"]
+    allowed_pr_authors: ["packit-stg", "packit"]
     dist_git_branches:
       - fedora-all
       - epel-8


### PR DESCRIPTION
Specify allowed_pr_authors for koji build job so that Packit reacts
to PRs both by packit and packit-stg.