### PR TITLE
Install flexmock from PyPI only in EL9

### DIFF
--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -2,11 +2,11 @@ summary:
   Unit & integration tests
 discover+:
   filter: tier:1
-prepare:
-  # flexmock is not in EPEL 9, install it from PyPI
-  - name: pip
-    how: install
-    package: python3-pip
-  - name: flexmock
-    how: shell
-    script: pip3 install flexmock
+adjust:
+  - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
+    because: "flexmock is not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
+    prepare:
+      - how: install
+        package: python3-pip
+      - how: shell
+        script: pip3 install flexmock

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -1,8 +1,14 @@
 summary:
   Unit & integration tests
 require:
+  - python3-flexmock
   - python3-pytest
   - python3-specfile
+adjust:
+  - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
+    because: "flexmock is not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
+    require-:
+      - python3-flexmock
 tag:
   - basic
 tier: 1


### PR DESCRIPTION
The version of pytest packaged in EL8 is too old for the latest flexmock from PyPI. Avoid issues by only installing flexmock from PyPI where necessary.