### PR TITLE
Reinitalize macros before each parse

### DIFF
--- a/specfile/rpm.py
+++ b/specfile/rpm.py
@@ -302,17 +302,22 @@ class RPM:
         Raises:
             RPMException, if parsing error occurs.
         """
-        Macros.reinit()
-        for name, value in macros or []:
-            Macros.define(name, value)
-        Macros.define("_sourcedir", str(sourcedir))
+
+        def reinit_macros():
+            Macros.reinit()
+            for name, value in macros or []:
+                Macros.define(name, value)
+            Macros.define("_sourcedir", str(sourcedir))
+
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(content.encode())
             tmp.flush()
             try:
+                reinit_macros()
                 with capture_stderr() as stderr:
                     # do a non-build parse first
                     spec = rpm.spec(tmp.name, rpm.RPMSPEC_ANYARCH | rpm.RPMSPEC_FORCE)
+                reinit_macros()
                 with RPM.make_dummy_sources([s for s, _, _ in spec.sources], sourcedir):
                     with capture_stderr() as stderr:
                         # do a full parse with dummy sources


### PR DESCRIPTION
The first non-build parse of a spec file affects macros in the global context and they can have effect on the second parse and cause issues. Prevent that by reinitializing macros again before the second parse.