### PR TITLE
Enable TF tests on pull requests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -54,6 +54,12 @@ jobs:
       - fedora-all
       - epel-9
 
+  - job: tests
+    trigger: pull_request
+    targets:
+      - fedora-all
+      - epel-9
+
   - job: copr_build
     trigger: commit
     branch: main


### PR DESCRIPTION
We want to run the test suite on EL 9, and since `%check` is disabled on EL 9 because of flexmock absence, we need to run it in Testing Farm.