### PR TITLE
Provide context for macro expansions

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -233,7 +233,9 @@ class Specfile:
         """
         with self.sections() as sections, self.tags(sections.package) as tags:
             sourcelists = [
-                (s, Sourcelist.parse(s)) for s in sections if s.name == "sourcelist"
+                (s, Sourcelist.parse(s, context=self))
+                for s in sections
+                if s.name == "sourcelist"
             ]
             try:
                 yield Sources(
@@ -242,6 +244,7 @@ class Specfile:
                     allow_duplicates,
                     default_to_implicit_numbering,
                     default_source_number_digits,
+                    context=self,
                 )
             finally:
                 for section, sourcelist in sourcelists:
@@ -267,7 +270,9 @@ class Specfile:
         """
         with self.sections() as sections, self.tags(sections.package) as tags:
             patchlists = [
-                (s, Sourcelist.parse(s)) for s in sections if s.name == "patchlist"
+                (s, Sourcelist.parse(s, context=self))
+                for s in sections
+                if s.name == "patchlist"
             ]
             try:
                 yield Patches(
@@ -276,6 +281,7 @@ class Specfile:
                     allow_duplicates,
                     default_to_implicit_numbering,
                     default_source_number_digits,
+                    context=self,
                 )
             finally:
                 for section, patchlist in patchlists:
@@ -572,7 +578,9 @@ class Specfile:
         entities.update({k.upper(): v for k, v in entities.items() if v.type == Tag})
 
         def update(value, requested_value):
-            regex, template = ValueParser.construct_regex(value, entities.keys())
+            regex, template = ValueParser.construct_regex(
+                value, entities.keys(), context=self
+            )
             m = regex.match(requested_value)
             if m:
                 d = m.groupdict()

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -333,3 +333,14 @@ def test_update_tag(spec_macros):
         assert md.minorver.body == "2"
     with spec.sources() as sources:
         assert sources[1].location == "tests-86.tar.xz"
+
+
+def test_multiple_instances(spec_minimal, spec_autosetup):
+    spec1 = Specfile(spec_minimal)
+    spec2 = Specfile(spec_autosetup)
+    spec1.version = "14.2"
+    assert spec2.expanded_version == "0.1"
+    with spec2.sources() as sources:
+        assert sources[0].expanded_location == "test-0.1.tar.xz"
+        sources.append("tests-%{version}.tar.xz")
+        assert sources[1].expanded_location == "tests-0.1.tar.xz"


### PR DESCRIPTION
When using multiple instances of `Specfile`, macros have to be expanded in the right context (because RPM uses a single global macro context, so this global context has to be emptied and repopulated on every context switch).

RELEASE NOTES BEGIN
Fixed an issue with multiple instances of `Specfile` not expanding macros in the right context.
RELEASE NOTES END