### PR TITLE
Add support for localized tags and tags with qualifiers, and ignore invalid section names

### DIFF
--- a/tests/unit/test_sections.py
+++ b/tests/unit/test_sections.py
@@ -67,6 +67,22 @@ def test_parse_case_insensitive():
     assert sections[2] == ["Requires: bar"]
 
 
+def test_parse_invalid_name():
+    sections = Sections.parse(
+        [
+            "%description",
+            "This is a description.",
+            "",
+            "%description(fr)",
+            "Ceci est une description.",
+            "",
+        ]
+    )
+    assert len(sections) == 2  # including empty preamble
+    assert sections[1].name == "description"
+    assert sections.description[2] == "%description(fr)"
+
+
 def test_copy_sections():
     sections = Sections([Section("package"), Section("package bar")])
     sections_copy = copy.deepcopy(sections)

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -40,6 +40,9 @@ def test_parse():
                 "%if 0",
                 "Epoch:   1",
                 "%endif",
+                "",
+                "Requires:          make",
+                "Requires(post):    bash",
             ],
         ),
         Section(
@@ -58,6 +61,9 @@ def test_parse():
                 "",
                 "",
                 "",
+                "",
+                "Requires:          make",
+                "Requires(post):    bash",
             ],
         ),
     )
@@ -72,6 +78,9 @@ def test_parse():
     assert tags.release.comments[0].prefix == "  # "
     assert tags.epoch.name == "Epoch"
     assert not tags.epoch.valid
+    assert tags.requires.value == "make"
+    assert "requires(post)" in tags
+    assert tags[-1].name == "Requires(post)"
 
 
 def test_get_raw_section_data():
@@ -99,8 +108,12 @@ def test_get_raw_section_data():
                 Comments([Comment("this is a valid comment", "  # ")]),
             ),
             Tag("Epoch", "1", "", ":   ", Comments([], ["", "%if 0"])),
+            Tag(
+                "Requires", "make", "make", ":          ", Comments([], ["%endif", ""])
+            ),
+            Tag("Requires(post)", "bash", "bash", ":    ", Comments()),
         ],
-        ["%endif"],
+        [],
     )
     assert tags.get_raw_section_data() == [
         "%global ver_major 1",
@@ -116,6 +129,9 @@ def test_get_raw_section_data():
         "%if 0",
         "Epoch:   1",
         "%endif",
+        "",
+        "Requires:          make",
+        "Requires(post):    bash",
     ]
 
 


### PR DESCRIPTION
Fixes #120.
Fixes #126.

RELEASE NOTES BEGIN
`specfile` now supports localized tags (e.g. `Summary(fr)`) and tags with qualifiers (e.g. `Requires(post)`).
It also follows more closely rpm parsing logic and doesn't fail on invalid section names.
RELEASE NOTES END