### PR TITLE
Sanitize environment for shell expansions

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -15,5 +15,6 @@ SPEC_INCLUDES = DATA_DIR / "spec_includes"
 SPEC_MACROS = DATA_DIR / "spec_macros"
 SPEC_MULTIPLE_SOURCES = DATA_DIR / "spec_multiple_sources"
 SPEC_COMMENTED_PATCHES = DATA_DIR / "spec_commented_patches"
+SPEC_SHELL_EXPANSIONS = DATA_DIR / "spec_shell_expansions"
 
 SPECFILE = "test.spec"

--- a/tests/data/spec_shell_expansions/test.spec
+++ b/tests/data/spec_shell_expansions/test.spec
@@ -1,0 +1,21 @@
+%global upstream_version 1035.42
+%global package_version %(printf "%'.4f" %{upstream_version})
+
+%global numeric_locale %(locale | grep LC_NUMERIC)
+
+
+Name:           test
+Version:        %{package_version}
+Release:        1%{?dist}
+Summary:        Test package
+
+License:        MIT
+
+
+%description
+Test package
+
+
+%changelog
+* Thu Jun 07 2018 Nikola Forró <nforro@redhat.com> - 0.1-1
+- first version

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,7 @@ from tests.constants import (
     SPEC_MULTIPLE_SOURCES,
     SPEC_PATCHLIST,
     SPEC_RPMAUTOSPEC,
+    SPEC_SHELL_EXPANSIONS,
     SPEC_TRADITIONAL,
     SPECFILE,
 )
@@ -87,4 +88,11 @@ def spec_multiple_sources(tmp_path):
 def spec_commented_patches(tmp_path):
     destination = tmp_path / "spec_commented_patches"
     shutil.copytree(SPEC_COMMENTED_PATCHES, destination)
+    return destination / SPECFILE
+
+
+@pytest.fixture(scope="function")
+def spec_shell_expansions(tmp_path):
+    destination = tmp_path / "spec_shell_expansions"
+    shutil.copytree(SPEC_SHELL_EXPANSIONS, destination)
     return destination / SPECFILE

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -369,3 +369,9 @@ def test_includes(spec_includes):
     assert not spec.expand("%patches")
     with spec.sections() as sections:
         assert sections.description[0] == "%include %{SOURCE2}"
+
+
+def test_shell_expansions(spec_shell_expansions):
+    spec = Specfile(spec_shell_expansions)
+    assert spec.expanded_version == "1035.4200"
+    assert "C.UTF-8" in spec.expand("%numeric_locale")


### PR DESCRIPTION
Spec files can contain arbitrary code that is run when RPM parses the spec file. This code runs in user's environment that can affect
the execution.
Sanitize the environment before passing control to RPM to avoid surprises.

Fixes #124.
Fixes #127.