### PR TITLE
Fake missing sources referenced from shell expansions

### DIFF
--- a/tests/data/spec_includes/provides.inc
+++ b/tests/data/spec_includes/provides.inc
@@ -1,0 +1,3 @@
+test1
+test2
+test3

--- a/tests/data/spec_includes/test.spec
+++ b/tests/data/spec_includes/test.spec
@@ -7,13 +7,16 @@ License:        MIT
 
 Source0:        %{name}-%{version}.tar.xz
 Source1:        patches.inc
-Source2:        description.inc
+Source2:        provides.inc
+Source3:        description.inc
 
 %include %{SOURCE1}
 
+Provides:       test0-%{version} %(sed "s/$/-%{version}/" %{SOURCE2} | tr "\n" " ")
+
 
 %description
-%include %{SOURCE2}
+%include %{SOURCE3}
 
 
 %prep

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -356,9 +356,13 @@ def test_includes(spec_includes):
     with spec.patches() as patches:
         assert not patches
     assert spec.expand("%patches")
+    with spec.tags() as tags:
+        assert tags.provides.value.startswith("test0-%{version} %(")
+        for i in range(4):
+            assert f"test{i}-0.1" in tags.provides.expanded_value
     with spec.sections() as sections:
-        assert sections.description[0] == "%include %{SOURCE2}"
-    for inc in ["patches.inc", "description.inc"]:
+        assert sections.description[0] == "%include %{SOURCE3}"
+    for inc in ["patches.inc", "provides.inc", "description.inc"]:
         (spec.sourcedir / inc).unlink()
     with pytest.raises(RPMException):
         spec = Specfile(spec_includes)
@@ -367,8 +371,11 @@ def test_includes(spec_includes):
     with spec.patches() as patches:
         assert not patches
     assert not spec.expand("%patches")
+    with spec.tags() as tags:
+        assert tags.provides.value.startswith("test0-%{version} %(")
+        assert tags.provides.expanded_value == "test0-0.1"
     with spec.sections() as sections:
-        assert sections.description[0] == "%include %{SOURCE2}"
+        assert sections.description[0] == "%include %{SOURCE3}"
 
 
 def test_shell_expansions(spec_shell_expansions):


### PR DESCRIPTION
Sources referenced from shell expansions are effectively equivalent to sources included using the `%include` directive, for instance `%include %{SOURCE1}` does the same thing as `%(cat %{SOURCE1})`.

Treat such sources that are not available the same way as missing included sources.

Related to #122.