### PR TITLE
Fix parsing empty lines inside changelog entries

### DIFF
--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -306,26 +306,30 @@ class Changelog(collections.UserList):
         Returns:
             Constructed instance of `Changelog` class.
         """
+
+        def extract_following_lines(content):
+            following_lines: List[str] = []
+            while content and not content[-1].strip():
+                following_lines.insert(0, content.pop())
+            return following_lines
+
         data: List[ChangelogEntry] = []
         predecessor = []
         header = None
         content: List[str] = []
-        following_lines: List[str] = []
         for line in section:
             if line.startswith("*"):
                 if header:
+                    following_lines = extract_following_lines(content)
                     data.insert(0, ChangelogEntry(header, content, following_lines))
                 header = line
                 content = []
-                following_lines = []
             elif header:
-                if line.strip():
-                    content.append(line)
-                else:
-                    following_lines.append(line)
+                content.append(line)
             else:
                 predecessor.append(line)
         if header:
+            following_lines = extract_following_lines(content)
             data.insert(0, ChangelogEntry(header, content, following_lines))
         return cls(data, predecessor)
 

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -140,6 +140,12 @@ def test_parse():
         Section(
             "changelog",
             [
+                "* Mon Nov 21 2022 Nikola Forró <nforro@redhat.com> - 0.3-1",
+                "- this is a formatted",
+                "  changelog entry",
+                "",
+                "- here is another item",
+                "",
                 "* Thu Jan 13 08:12:41 UTC 2022 Nikola Forró <nforro@redhat.com> - 0.2-2",
                 "- rebuilt",
                 "",
@@ -155,7 +161,7 @@ def test_parse():
             ],
         )
     )
-    assert len(changelog) == 4
+    assert len(changelog) == 5
     assert (
         changelog[0].header
         == "* Tue May 04 2021 Nikola Forró <nforro@redhat.com> - 0.1-1"
@@ -182,6 +188,17 @@ def test_parse():
     )
     assert changelog[3].content == ["- rebuilt"]
     assert changelog[3].extended_timestamp
+    assert (
+        changelog[4].header
+        == "* Mon Nov 21 2022 Nikola Forró <nforro@redhat.com> - 0.3-1"
+    )
+    assert changelog[4].content == [
+        "- this is a formatted",
+        "  changelog entry",
+        "",
+        "- here is another item",
+    ]
+    assert not changelog[4].extended_timestamp
 
 
 def test_get_raw_section_data():
@@ -213,9 +230,26 @@ def test_get_raw_section_data():
                 ["- rebuilt"],
                 "0.2-2",
             ),
+            ChangelogEntry.assemble(
+                datetime.date(2022, 11, 21),
+                "Nikola Forró <nforro@redhat.com>",
+                [
+                    "- this is a formatted",
+                    "  changelog entry",
+                    "",
+                    "- here is another item",
+                ],
+                "0.3-1",
+            ),
         ]
     )
     assert changelog.get_raw_section_data() == [
+        "* Mon Nov 21 2022 Nikola Forró <nforro@redhat.com> - 0.3-1",
+        "- this is a formatted",
+        "  changelog entry",
+        "",
+        "- here is another item",
+        "",
         "* Thu Jan 13 08:12:41 UTC 2022 Nikola Forró <nforro@redhat.com> - 0.2-2",
         "- rebuilt",
         "",


### PR DESCRIPTION
Fixes #139.

RELEASE NOTES BEGIN
Fixed an issue that caused empty lines originally inside changelog entries to appear at the end.
RELEASE NOTES END