### PR TITLE
Don't assume that expanded value of a tag can't be None

### DIFF
--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -38,7 +38,7 @@ class Source(ABC):
 
     @property
     @abstractmethod
-    def expanded_location(self) -> str:
+    def expanded_location(self) -> Optional[str]:
         """Location of the source after expanding macros."""
         ...
 
@@ -56,7 +56,7 @@ class Source(ABC):
 
     @property
     @abstractmethod
-    def expanded_filename(self) -> str:
+    def expanded_filename(self) -> Optional[str]:
         """Filename of the source after expanding macros."""
         ...
 
@@ -133,7 +133,7 @@ class TagSource(Source):
         self._tag.value = value
 
     @property
-    def expanded_location(self) -> str:
+    def expanded_location(self) -> Optional[str]:
         """Location of the source after expanding macros."""
         return self._tag.expanded_value
 
@@ -143,8 +143,10 @@ class TagSource(Source):
         return get_filename_from_location(self._tag.value)
 
     @property
-    def expanded_filename(self) -> str:
+    def expanded_filename(self) -> Optional[str]:
         """Filename of the source after expanding macros."""
+        if self._tag.expanded_value is None:
+            return None
         return get_filename_from_location(self._tag.expanded_value)
 
     @property

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -187,7 +187,7 @@ class Tag:
         self,
         name: str,
         value: str,
-        expanded_value: str,
+        expanded_value: Optional[str],
         separator: str,
         comments: Comments,
     ) -> None:
@@ -230,8 +230,9 @@ class Tag:
 
     def __repr__(self) -> str:
         comments = repr(self.comments)
+        expanded_value = repr(self._expanded_value)
         return (
-            f"Tag('{self.name}', '{self.value}', '{self._expanded_value}', "
+            f"Tag('{self.name}', '{self.value}', {expanded_value}, "
             f"'{self._separator}', {comments})"
         )
 
@@ -249,7 +250,7 @@ class Tag:
         return self._expanded_value is not None
 
     @property
-    def expanded_value(self) -> str:
+    def expanded_value(self) -> Optional[str]:
         """Value of the tag after expanding macros and evaluating all conditions."""
         return self._expanded_value
 


### PR DESCRIPTION
This is just a trivial bugfix, preventing traceback in `get_filename_from_location()`.