### PR TITLE
Make sure expanded_release doesn't contain the dist suffix

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -530,7 +530,7 @@ class Specfile:
     @property
     def expanded_release(self) -> str:
         """Release string without the dist suffix with macros expanded."""
-        return self.expand(self.release)
+        return self.expand(self.release, extra_macros=[("dist", "")])
 
     def set_version_and_release(self, version: str, release: str = "1") -> None:
         """


### PR DESCRIPTION
If the `Release` tag is defined by a macro, for example:

```spec
%global rel 28%{?dist}
Release:    %{rel}
```

then `Specfile.release` returns `%{rel}`, as expected, but, assuming `%dist` is defined as `.fc37`, `Specfile.expanded_release` returns `28.fc37` rather than `28`.
Fix that by explicitly defining `%dist` to be an empty string when expanding the release.