### PR TITLE
Fix Specfile.update_tag()

### DIFF
--- a/specfile/macro_definitions.py
+++ b/specfile/macro_definitions.py
@@ -37,6 +37,20 @@ class MacroDefinition:
         macro = "%global" if self.is_global else "%define"
         return f"{ws[0]}{macro}{ws[1]}{self.name}{ws[2]}{self.body}{ws[3]}"
 
+    def get_position(self, container: "MacroDefinitions") -> int:
+        """
+        Gets position of this macro definition in the spec file.
+
+        Args:
+            container: `MacroDefinitions` instance that contains this macro definition.
+
+        Returns:
+            Position expressed as line number (starting from 0).
+        """
+        return sum(
+            len(md.get_raw_data()) for md in container[: container.index(self)]
+        ) + len(self._preceding_lines)
+
     def get_raw_data(self) -> List[str]:
         result = self._preceding_lines.copy()
         ws = self._whitespace

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -254,6 +254,21 @@ class Tag:
         """Value of the tag after expanding macros and evaluating all conditions."""
         return self._expanded_value
 
+    def get_position(self, container: "Tags") -> int:
+        """
+        Gets position of this tag in a section.
+
+        Args:
+            container: `Tags` instance that contains this tag.
+
+        Returns:
+            Position expressed as line number (starting from 0).
+        """
+        return sum(
+            len(t.comments.get_raw_data()) + 1
+            for t in container[: container.index(self)]
+        ) + len(self.comments.get_raw_data())
+
 
 class Tags(collections.UserList):
     """

--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -5,7 +5,7 @@ import itertools
 import re
 from abc import ABC
 from string import Template
-from typing import TYPE_CHECKING, List, Optional, Pattern, Tuple
+from typing import TYPE_CHECKING, List, Optional, Pattern, Set, Tuple
 
 from specfile.exceptions import UnterminatedMacroException
 from specfile.macros import Macros
@@ -254,7 +254,7 @@ class ValueParser:
     def construct_regex(
         cls,
         value: str,
-        modifiable_entities: List[str],
+        modifiable_entities: Set[str],
         context: Optional["Specfile"] = None,
     ) -> Tuple[Pattern, Template]:
         """

--- a/tests/data/spec_macros/test.spec
+++ b/tests/data/spec_macros/test.spec
@@ -3,11 +3,12 @@
 %global patchver 2
 %global prever rc2
 %global package_version %{majorver}.%{minorver}.%{patchver}
+%global release 1%{?dist}
 
 
 Name:           test
 Version:        %{package_version}%{?prever:~%{prever}}
-Release:        1%{?dist}
+Release:        %{release}
 Summary:        Test package
 
 License:        MIT

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -311,6 +311,10 @@ def test_update_tag(spec_macros):
         assert md.prever.body == "alpha1"
         assert md.package_version.body == "4.0"
     assert spec.version == "5.3.3"
+    spec.update_tag("Release", "2%{?dist}")
+    assert spec.raw_release == "%{release}"
+    with spec.macro_definitions() as md:
+        assert md.release.body == "2%{?dist}"
     spec.update_tag(
         "Source0",
         "https://example.com/archived_releases/test/v6.0.0/test-v6.0.0.tar.xz",


### PR DESCRIPTION
There can be multiple macro definitions with the same name (redefined macros) and macro definitions with a name equal to a tag. Previously, only one instance of entities sharing a name was taken into consideration, with tags being preferred over macro definitions. That's no longer the case, and also only entities preceding the tag being updated are taken into consideration, because only those can have effect on the tag.