### PR TITLE
Make context managers better

### DIFF
--- a/specfile/context_management.py
+++ b/specfile/context_management.py
@@ -1,0 +1,141 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import collections
+import contextlib
+import io
+import os
+import pickle
+import sys
+import tempfile
+import types
+from typing import Any, Callable, Dict, Generator, List, Optional, overload
+
+
+@contextlib.contextmanager
+def capture_stderr() -> Generator[List[bytes], None, None]:
+    """
+    Context manager for capturing output to stderr. A stderr output of anything run
+    in its context will be captured in the target variable of the with statement.
+
+    Yields:
+        List of captured lines.
+    """
+    fileno = sys.__stderr__.fileno()
+    with tempfile.TemporaryFile() as stderr, os.fdopen(os.dup(fileno)) as backup:
+        sys.stderr.flush()
+        os.dup2(stderr.fileno(), fileno)
+        data: List[bytes] = []
+        try:
+            yield data
+        finally:
+            sys.stderr.flush()
+            os.dup2(backup.fileno(), fileno)
+            stderr.flush()
+            stderr.seek(0, io.SEEK_SET)
+            data.extend(stderr.readlines())
+
+
+class GeneratorContextManager(contextlib._GeneratorContextManager):
+    """
+    Extended contextlib._GeneratorContextManager that provides get() method.
+    """
+
+    def __init__(self, function: Callable) -> None:
+        super().__init__(function, tuple(), {})
+
+    def __del__(self) -> None:
+        # make sure the generator is fully consumed, as it is possible
+        # that neither __enter__() nor content() have been called
+        collections.deque(self.gen, maxlen=0)
+
+    @property
+    def content(self) -> Any:
+        """
+        Fully consumes the underlying generator and returns the yielded value.
+
+        Returns:
+            Value that would normally be the target variable of an associated with statement.
+
+        Raises:
+            StopIteration if the underlying generator is already exhausted.
+        """
+        result = next(self.gen)
+        next(self.gen, None)
+        return result
+
+
+class ContextManager:
+    """
+    Class for decorating generator functions that should act as a context manager.
+
+    Just like with contextlib.contextmanager, the generator returned from the decorated function
+    must yield exactly one value that will be used as the target variable of the with statement.
+    If the same function with the same arguments is called again from within previously generated
+    context, the generator will be ignored and the target variable will be reused.
+
+    Attributes:
+        function: Decorated generator function.
+        generators: Mapping of serialized function arguments to generators.
+        values: Mapping of serialized function arguments to yielded values.
+    """
+
+    def __init__(self, function: Callable) -> None:
+        self.function = function
+        self.is_bound = False
+        self.generators: Dict[bytes, Generator[Any, None, None]] = {}
+        self.values: Dict[bytes, Any] = {}
+
+    @overload
+    def __get__(self, obj: None, objtype: Optional[type] = None) -> "ContextManager":
+        pass
+
+    @overload
+    def __get__(self, obj: object, objtype: Optional[type] = None) -> types.MethodType:
+        pass
+
+    # implementing __get__() makes the class a non-data descriptor,
+    # so it can be used as method decorator
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        self.is_bound = True
+        return types.MethodType(self, obj)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> GeneratorContextManager:
+        # serialize the passed arguments, excluding cls/self if present
+        key = pickle.dumps(
+            (args[1:] if self.is_bound else args, sorted(kwargs.items())),
+            protocol=pickle.HIGHEST_PROTOCOL,
+        )
+        if (
+            key in self.generators
+            # gi_frame is None only in case generator is exhausted
+            and self.generators[key].gi_frame is not None  # type: ignore[attr-defined]
+        ):
+            # generator is suspended, use existing value
+            def existing_value():
+                try:
+                    yield self.values[key]
+                except KeyError:
+                    # if the generator is being consumed in GeneratorContextManager destructor,
+                    # self.values[key] could have already been deleted
+                    pass
+
+            return GeneratorContextManager(existing_value)
+        # create the generator
+        self.generators[key] = self.function(*args, **kwargs)
+        # first iteration yields the value
+        self.values[key] = next(self.generators[key])
+
+        def new_value():
+            try:
+                yield self.values[key]
+            finally:
+                # second iteration wraps things up
+                next(self.generators[key], None)
+                # the generator is now exhausted and the value is no longer valid
+                del self.generators[key]
+                del self.values[key]
+
+        return GeneratorContextManager(new_value)

--- a/specfile/macros.py
+++ b/specfile/macros.py
@@ -8,8 +8,8 @@ from typing import List, Optional
 
 import rpm
 
+from specfile.context_management import capture_stderr
 from specfile.exceptions import MacroRemovalException, RPMException
-from specfile.utils import capture_stderr
 
 MAX_REMOVAL_RETRIES = 20
 

--- a/specfile/spec_parser.py
+++ b/specfile/spec_parser.py
@@ -11,11 +11,12 @@ from typing import Iterator, List, Optional, Set, Tuple
 
 import rpm
 
+from specfile.context_management import capture_stderr
 from specfile.exceptions import RPMException
 from specfile.macros import Macros
 from specfile.sections import Section
 from specfile.tags import Tags
-from specfile.utils import capture_stderr, get_filename_from_location
+from specfile.utils import get_filename_from_location
 from specfile.value_parser import ConditionalMacroExpansion, ShellExpansion, ValueParser
 
 logger = logging.getLogger(__name__)

--- a/specfile/utils.py
+++ b/specfile/utils.py
@@ -2,13 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import collections
-import contextlib
-import io
-import os
 import re
-import sys
-import tempfile
-from typing import Iterator, List
 
 from specfile.constants import ARCH_NAMES
 from specfile.exceptions import SpecfileException
@@ -118,30 +112,6 @@ class NEVRA(NEVR):
             raise SpecfileException("Invalid NEVRA string.")
         n, e, v, r, a = m.groups()
         return cls(name=n, epoch=int(e) if e else 0, version=v, release=r, arch=a)
-
-
-@contextlib.contextmanager
-def capture_stderr() -> Iterator[List[bytes]]:
-    """
-    Context manager for capturing output to stderr. A stderr output of anything run
-    in its context will be captured in the target variable of the with statement.
-
-    Yields:
-        List of captured lines.
-    """
-    fileno = sys.__stderr__.fileno()
-    with tempfile.TemporaryFile() as stderr, os.fdopen(os.dup(fileno)) as backup:
-        sys.stderr.flush()
-        os.dup2(stderr.fileno(), fileno)
-        data: List[bytes] = []
-        try:
-            yield data
-        finally:
-            sys.stderr.flush()
-            os.dup2(backup.fileno(), fileno)
-            stderr.flush()
-            stderr.seek(0, io.SEEK_SET)
-            data.extend(stderr.readlines())
 
 
 def get_filename_from_location(location: str) -> str:

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -391,3 +391,18 @@ def test_shell_expansions(spec_shell_expansions):
     spec = Specfile(spec_shell_expansions)
     assert spec.expanded_version == "1035.4200"
     assert "C.UTF-8" in spec.expand("%numeric_locale")
+
+
+def test_context_management(spec_autosetup):
+    spec = Specfile(spec_autosetup)
+    with spec.tags() as tags:
+        tags.license.value = "BSD"
+        assert spec.license == "BSD"
+        spec.license = "BSD-3-Clause"
+        tags.patch0.value = "first_patch.patch"
+        with spec.patches() as patches:
+            assert patches[0].location == "first_patch.patch"
+            patches[0].location = "patch_0.patch"
+    assert spec.license == "BSD-3-Clause"
+    with spec.patches() as patches:
+        assert patches[0].location == "patch_0.patch"


### PR DESCRIPTION
This commit introduces a new `ContextManager` decorator that builds on top of `contextlib.contextmanager` and effectively makes context managers a singleton. Any nested context of the same kind will be the same as the outermost context of that particular kind.

This makes it possible, for example, to set properties that internally use context managers inside an existing context, or in general mix and nest context managers almost freely.

There are still instances of conflicting context managers, for example `macro_definitions()` and `sections()`, that, when combined, will overwrite each other's underlying data. All such instances will be documented.

Now it is also possible to access data directly, avoiding the `with` statement, by using `GeneratorContextManager.content` property (I'm open to suggestions how to name it better):

```python
for tag in spec.tags().content:
    print(f"{tag.name}: {tag.expanded_value}")
```

No modifications will be preserved though.

---

RELEASE NOTES BEGIN

Context managers (`Specfile.sections()`, `Specfile.tags()` etc.) can now be nested and combined together (with one exception - `Specfile.macro_definitions()`), and it is also possible to use tag properties (e.g. `Specfile.version`, `Specfile.license`) inside them. It is also possible to access the data directly, avoiding the `with` statement, by using the `content` property (e.g. `Specfile.tags().content`), but be aware that no modifications done to such data will be preserved. You must use `with` to make changes.

RELEASE NOTES END