### PR TITLE
Make specfile PEP 561 compliant

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,6 @@ testing =
 [options.packages.find]
 exclude =
     tests*
+
+[options.package_data]
+* = py.typed


### PR DESCRIPTION
This allows mypy to recognize specfile type hints in projects importing it and avoids the following error:

`Skipping analyzing "specfile": module is installed, but missing library stubs or py.typed marker`