### PR TITLE
Move from license_file to license_files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,8 @@ url = https://github.com/packit/specfile
 author = Red Hat
 author_email = user-cont-team@redhat.com
 license = MIT
-license_file = LICENSE
+license_files =
+    LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Environment :: Console


### PR DESCRIPTION
Setup.cfg license_file was deprecated in favor of license_files some time ago.

Fixes

Setup.cfg uses a deprecated value.

Related to

Merge before/after

RELEASE NOTES BEGIN

`setup.cfg` now uses `license_files` instead of deprecated `license_file`.

RELEASE NOTES END
