### PR TITLE
Run Packit tests with new specfile changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing Guidelines
+
+Please follow common guidelines for our projects [here](https://github.com/packit/contributing).
+
+## Running tests
+
+The easiest way of running tests locally is inside containers:
+
+```bash
+# Needs to be re-run only when dependencies change
+make build-test-image
+
+# Run the whole test suite
+make check-in-container
+
+# Run only unit tests
+TEST_TARGET=./tests/unit make check-in-container
+```
+
+To reproduce a testing environment similar to the one used in Fedora CI,
+[tmt](https://github.com/teemtee/tmt) can be used (this will run tests in a
+virtual machine, for other options, refer to the
+[tmt documentation](https://tmt.readthedocs.io/en/stable/):
+
+```bash
+tmt run plan -n full
+```
+
+Since Packit directly relies on specfile, we also have a reverse-dependency
+test that runs Packit's tests with the currently checked out specfile.
+In Github pull requests, this is done automatically. To reproduce this
+behavior locally, you first need to build an RPM package from the current
+checkout, e.g. by using `packit build locally`:
+
+```bash
+# Build using the current sources using rpmbuild, results are placed inside noarch/
+packit build locally
+
+# The plan installs RPMs from the noarch/ directory. The VM image that you use
+# must match the built RPM package Fedora version so that the package can be installed.
+tmt -c how=integration run -avvv plan -n packit-integration provision -h virtual -i fedora-36
+```

--- a/plans/git_reference.py
+++ b/plans/git_reference.py
@@ -5,10 +5,25 @@ from pathlib import Path
 
 import fmf
 
+# Set discover of specfile tests to a fixed commit
 tree_root = Path.cwd().absolute()
-node = fmf.Tree(tree_root).find("/plans")
-with node as data:
+tree = fmf.Tree(tree_root)
+main_node = tree.find("/plans")
+with main_node as data:
     data["discover"]["url"] = "https://github.com/packit/specfile.git"
     data["discover"]["ref"] = (
         subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+    )
+
+
+# Set discover of packit integration tests to the current main
+packit_node = tree.find("/plans/packit-integration")
+with packit_node as data:
+    data["discover"]["ref"] = (
+        subprocess.check_output(
+            ["git", "ls-remote", "https://github.com/packit/packit", "main"]
+        )
+        .decode()
+        .strip()
+        .split()[0]
     )

--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -1,0 +1,20 @@
+discover:
+    how: fmf
+    url: https://github.com/packit/packit
+    filter: tier:0 | tier:1
+
+adjust:
+  - when: "how == integration"
+    because: "provide latest python-specfile rpm when running locally"
+    prepare+:
+      - name: python3-specfile rpm
+        how: install
+        directory: noarch/
+
+  - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
+    because: "flexmock and deepdiff are not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
+    prepare+:
+      - how: install
+        package: python3-pip
+      - how: shell
+        script: pip3 install flexmock deepdiff


### PR DESCRIPTION
Fixes: #163 

I hope that the RPM is installed in testing farm as an artifact, so this should work but let's see - I added a breaking change that should cause packit tests to fail