### PR TITLE
Format repr of all classes

### DIFF
--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -9,6 +9,7 @@ from typing import List, Optional, SupportsIndex, Union, overload
 import rpm
 
 from specfile.exceptions import SpecfileException
+from specfile.formatter import formatted
 from specfile.sections import Section
 from specfile.utils import EVR
 
@@ -64,10 +65,9 @@ class ChangelogEntry:
     def __str__(self) -> str:
         return f"{self.header}\n" + "\n".join(self.content) + "\n"
 
+    @formatted
     def __repr__(self) -> str:
-        content = repr(self.content)
-        following_lines = repr(self._following_lines)
-        return f"ChangelogEntry('{self.header}', {content}, {following_lines})"
+        return f"ChangelogEntry({self.header!r}, {self.content!r}, {self._following_lines!r})"
 
     @property
     def evr(self) -> Optional[str]:
@@ -214,10 +214,9 @@ class Changelog(collections.UserList):
     def __str__(self) -> str:
         return "\n".join(str(i) for i in reversed(self.data))
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        predecessor = repr(self._predecessor)
-        return f"Changelog({data}, {predecessor})"
+        return f"Changelog({self.data!r}, {self._predecessor!r})"
 
     @overload
     def __getitem__(self, i: SupportsIndex) -> ChangelogEntry:

--- a/specfile/context_management.py
+++ b/specfile/context_management.py
@@ -3,6 +3,7 @@
 
 import collections
 import contextlib
+import functools
 import io
 import os
 import pickle
@@ -85,6 +86,7 @@ class ContextManager:
         self.is_bound = False
         self.generators: Dict[bytes, Generator[Any, None, None]] = {}
         self.values: Dict[bytes, Any] = {}
+        functools.update_wrapper(self, function)
 
     @overload
     def __get__(self, obj: None, objtype: Optional[type] = None) -> "ContextManager":

--- a/specfile/formatter.py
+++ b/specfile/formatter.py
@@ -1,0 +1,132 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import ast
+import functools
+from typing import Callable
+
+from specfile.exceptions import SpecfileException
+
+
+def format_expression(expression: str, line_length_threshold: int = 80) -> str:
+    """
+    Formats the specified Python expression.
+
+    Only supports a small subset of Python AST that should be sufficient for use in __repr__().
+
+    Args:
+        expression: Python expression to reformat.
+        line_length_threshold: Threshold for line lengths. It's not a hard limit,
+          it can be exceeded in some cases.
+
+    Returns:
+        Formatted expression.
+
+    Raises:
+        SyntaxError if the expression is not parseable.
+        SpecfileException if there is an unsupported AST node in the expression.
+    """
+
+    def fmt(node, indent=0, prefix="", multiline=False):
+        result = " " * indent + prefix
+        if isinstance(node, ast.Constant):
+            result += repr(node.value)
+        elif isinstance(node, (ast.List, ast.Dict, ast.Call)):
+            if isinstance(node, ast.List):
+                start, end = "[", "]"
+                items = [(None, e) for e in node.elts]
+                delimiter = None
+            elif isinstance(node, ast.Dict):
+                start, end = "{", "}"
+                items = [(fmt(k, 0), v) for k, v in zip(node.keys, node.values)]
+                delimiter = ": "
+            elif isinstance(node, ast.Call):
+                start, end = f"{node.func.id}(", ")"
+                items = [(None, a) for a in node.args] + [
+                    (kw.arg, kw.value) for kw in node.keywords
+                ]
+                delimiter = "="
+            result += start
+            if multiline:
+                result += "\n"
+            while items:
+                key, value = items.pop(0)
+                result += fmt(
+                    value,
+                    indent + 4 if multiline else 0,
+                    f"{key}{delimiter}" if key else "",
+                )
+                if multiline:
+                    result += ",\n"
+                elif items:
+                    result += ", "
+            if multiline:
+                result += " " * indent
+            result += end
+        else:
+            raise SpecfileException(
+                f"Unsupported AST node: ast.{node.__class__.__name__}"
+            )
+        if not multiline and len(result) > line_length_threshold:
+            result = fmt(node, indent, prefix, True)
+        return result
+
+    def find_matching_bracket(value, index):
+        level = 0
+        for i in range(index, len(value)):
+            if value[i] == ">":
+                level -= 1
+                if level <= 0:
+                    return i + 1
+            elif value[i] == "<":
+                level += 1
+        return None
+
+    placeholders = []
+    while True:
+        try:
+            tree = ast.parse(expression, mode="eval")
+        except SyntaxError as e:
+            # some objects (e.g. enums) are not represented by a valid expression,
+            # replace their representation with placeholders
+            # (assume such a representation is enclosed in <> and doesn't spawn
+            # across multiple lines)
+            lines = expression.splitlines()
+            if not e.lineno or not e.offset:
+                raise
+            if lines[e.lineno - 1][e.offset - 1] != "<":
+                raise
+            index = find_matching_bracket(lines[e.lineno - 1], e.offset - 1)
+            if not index:
+                raise
+            value = lines[e.lineno - 1][e.offset - 1 : index]
+            # convert the value to a string literal
+            placeholder = repr(value)
+            placeholders.append((placeholder, value))
+            lines[e.lineno - 1] = (
+                lines[e.lineno - 1][: e.offset - 1]
+                + placeholder
+                + lines[e.lineno - 1][index:]
+            )
+            expression = "\n".join(lines)
+        else:
+            break
+    result = fmt(tree.body)
+    # revert placeholders
+    for placeholder, value in placeholders:
+        result = result.replace(placeholder, value, 1)
+    return result
+
+
+def formatted(function: Callable[..., str]) -> Callable[..., str]:
+    """Decorator for formatting the output of __repr__()."""
+
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        result = function(*args, **kwargs)
+        try:
+            return format_expression(result)
+        except (SyntaxError, SpecfileException):
+            return result
+
+    return wrapper

--- a/specfile/macro_definitions.py
+++ b/specfile/macro_definitions.py
@@ -5,6 +5,8 @@ import collections
 import re
 from typing import List, Optional, SupportsIndex, Tuple, Union, overload
 
+from specfile.formatter import formatted
+
 
 class MacroDefinition:
     def __init__(
@@ -23,13 +25,11 @@ class MacroDefinition:
             preceding_lines.copy() if preceding_lines is not None else []
         )
 
+    @formatted
     def __repr__(self) -> str:
-        is_global = repr(self.is_global)
-        whitespace = repr(self._whitespace)
-        preceding_lines = repr(self._preceding_lines)
         return (
-            f"MacroDefinition('{self.name}', '{self.body}', {is_global}, "
-            f"{whitespace}, {preceding_lines})"
+            f"MacroDefinition({self.name!r}, {self.body!r}, {self.is_global!r}, "
+            f"{self._whitespace!r}, {self._preceding_lines!r})"
         )
 
     def __str__(self) -> str:
@@ -93,10 +93,9 @@ class MacroDefinitions(collections.UserList):
             self.data = data.copy()
         self._remainder = remainder.copy() if remainder is not None else []
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        remainder = repr(self._remainder)
-        return f"MacroDefinitions({data}, {remainder})"
+        return f"MacroDefinitions({self.data!r}, {self._remainder!r})"
 
     def __contains__(self, name: object) -> bool:
         try:

--- a/specfile/macro_options.py
+++ b/specfile/macro_options.py
@@ -8,6 +8,7 @@ from enum import Enum, auto
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union, overload
 
 from specfile.exceptions import MacroOptionsException
+from specfile.formatter import formatted
 
 
 class TokenType(Enum):
@@ -30,9 +31,9 @@ class Token(collections.abc.Hashable):
         self.type = type
         self.value = value
 
+    @formatted
     def __repr__(self) -> str:
-        type = repr(self.type)
-        return f"Token({type}, '{self.value}')"
+        return f"Token({self.type!r}, {self.value!r})"
 
     def __str__(self) -> str:
         if self.type == TokenType.WHITESPACE:
@@ -75,9 +76,9 @@ class Positionals(collections.abc.MutableSequence):
         """
         self._options = options
 
+    @formatted
     def __repr__(self) -> str:
-        options = repr(self._options)
-        return f"Positionals({options})"
+        return f"Positionals({self._options!r})"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, (Positionals, list)):
@@ -242,10 +243,9 @@ class MacroOptions(collections.abc.MutableMapping):
         self.optstring = optstring or ""
         self.defaults = defaults.copy() if defaults is not None else {}
 
+    @formatted
     def __repr__(self) -> str:
-        tokens = repr(self._tokens)
-        defaults = repr(self.defaults)
-        return f"MacroOptions({tokens}, '{self.optstring}', {defaults})"
+        return f"MacroOptions({self._tokens!r}, {self.optstring!r}, {self.defaults!r})"
 
     def __str__(self) -> str:
         return "".join(str(t) for t in self._tokens)

--- a/specfile/macros.py
+++ b/specfile/macros.py
@@ -10,6 +10,7 @@ import rpm
 
 from specfile.context_management import capture_stderr
 from specfile.exceptions import MacroRemovalException, RPMException
+from specfile.formatter import formatted
 
 MAX_REMOVAL_RETRIES = 20
 
@@ -63,10 +64,12 @@ class Macro(collections.abc.Hashable):
             return NotImplemented
         return self._key() == other._key()
 
+    @formatted
     def __repr__(self) -> str:
-        options = f"'{self.options}'" if self.options else "None"
-        level = repr(self.level)
-        return f"Macro('{self.name}', {options}, '{self.body}', {level}, {self.used})"
+        return (
+            f"Macro({self.name!r}, {self.options!r}, {self.body!r}, "
+            f"{self.level!r}, {self.used!r})"
+        )
 
 
 class Macros:

--- a/specfile/prep.py
+++ b/specfile/prep.py
@@ -6,6 +6,7 @@ import re
 from abc import ABC
 from typing import Any, Dict, List, Optional, SupportsIndex, Union, cast, overload
 
+from specfile.formatter import formatted
 from specfile.macro_options import MacroOptions
 from specfile.sections import Section
 from specfile.utils import split_conditional_macro_expansion
@@ -56,15 +57,14 @@ class PrepMacro(ABC):
             preceding_lines.copy() if preceding_lines is not None else []
         )
 
+    @formatted
     def __repr__(self) -> str:
-        options = repr(self.options)
-        preceding_lines = repr(self._preceding_lines)
         # determine class name dynamically so that inherited classes
         # don't have to reimplement __repr__()
         return (
-            f"{self.__class__.__name__}('{self.name}', {options}, "
-            f"'{self._delimiter}', '{self._prefix}', '{self._suffix}', "
-            f"{preceding_lines})"
+            f"{self.__class__.__name__}({self.name!r}, {self.options!r}, "
+            f"{self._delimiter!r}, {self._prefix!r}, {self._suffix!r}, "
+            f"{self._preceding_lines!r})"
         )
 
     def get_raw_data(self) -> List[str]:
@@ -159,10 +159,9 @@ class PrepMacros(collections.UserList):
             self.data = data.copy()
         self._remainder = remainder.copy() if remainder is not None else []
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        remainder = repr(self._remainder)
-        return f"PrepMacros({data}, {remainder})"
+        return f"PrepMacros({self.data!r}, {self._remainder!r})"
 
     def __contains__(self, item: object) -> bool:
         if isinstance(item, type):
@@ -251,9 +250,9 @@ class Prep(collections.abc.Container):
     def __init__(self, macros: PrepMacros) -> None:
         self.macros = macros.copy()
 
+    @formatted
     def __repr__(self) -> str:
-        macros = repr(self.macros)
-        return f"Prep({macros})"
+        return f"Prep({self.macros!r})"
 
     def __contains__(self, item: object) -> bool:
         return item in self.macros

--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -6,6 +6,7 @@ import re
 from typing import List, Optional, SupportsIndex, Union, cast, overload
 
 from specfile.constants import SECTION_NAMES
+from specfile.formatter import formatted
 
 # name for the implicit "preamble" section
 PREAMBLE = "package"
@@ -37,9 +38,9 @@ class Section(collections.UserList):
             return data
         return f"%{self.id}\n{data}"
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        return f"Section('{self.id}', {data})"
+        return f"Section({self.id!r}, {self.data!r})"
 
     def __copy__(self) -> "Section":
         return Section(self.id, self.data)
@@ -102,9 +103,9 @@ class Sections(collections.UserList):
     def __str__(self) -> str:
         return "".join(str(i) for i in self.data)
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        return f"Sections({data})"
+        return f"Sections({self.data!r})"
 
     def __copy__(self) -> "Sections":
         return Sections(self.data)

--- a/specfile/sourcelist.py
+++ b/specfile/sourcelist.py
@@ -4,6 +4,7 @@
 import collections
 from typing import TYPE_CHECKING, List, Optional, SupportsIndex, overload
 
+from specfile.formatter import formatted
 from specfile.macros import Macros
 from specfile.sections import Section
 from specfile.tags import Comments
@@ -44,9 +45,9 @@ class SourcelistEntry:
             return NotImplemented
         return self.location == other.location and self.comments == other.comments
 
+    @formatted
     def __repr__(self) -> str:
-        comments = repr(self.comments)
-        return f"SourcelistEntry('{self.location}', {comments})"
+        return f"SourcelistEntry({self.location!r}, {self.comments!r})"
 
     @property
     def expanded_location(self) -> str:
@@ -84,10 +85,9 @@ class Sourcelist(collections.UserList):
             self.data = data.copy()
         self._remainder = remainder.copy() if remainder is not None else []
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        remainder = repr(self._remainder)
-        return f"Sourcelist({data}, {remainder})"
+        return f"Sourcelist({self.data!r}, {self._remainder!r})"
 
     @overload
     def __getitem__(self, i: SupportsIndex) -> SourcelistEntry:

--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union, cast, overload
 
 from specfile.exceptions import DuplicateSourceException
+from specfile.formatter import formatted
 from specfile.macros import Macros
 from specfile.sourcelist import Sourcelist, SourcelistEntry
 from specfile.tags import Comments, Tag, Tags
@@ -84,11 +85,11 @@ class TagSource(Source):
         self._tag = tag
         self._number = number
 
+    @formatted
     def __repr__(self) -> str:
-        tag = repr(self._tag)
         # determine class name dynamically so that inherited classes
         # don't have to reimplement __repr__()
-        return f"{self.__class__.__name__}({tag}, {self._number})"
+        return f"{self.__class__.__name__}({self._tag!r}, {self._number!r})"
 
     def _extract_number(self) -> Optional[str]:
         """
@@ -174,11 +175,11 @@ class ListSource(Source):
         self._source = source
         self._number = number
 
+    @formatted
     def __repr__(self) -> str:
-        source = repr(self._source)
         # determine class name dynamically so that inherited classes
         # don't have to reimplement __repr__()
-        return f"{self.__class__.__name__}({source}, {self._number})"
+        return f"{self.__class__.__name__}({self._source!r}, {self._number!r})"
 
     @property
     def number(self) -> int:
@@ -252,16 +253,14 @@ class Sources(collections.abc.MutableSequence):
         self._default_source_number_digits = default_source_number_digits
         self._context = context
 
+    @formatted
     def __repr__(self) -> str:
-        tags = repr(self._tags)
-        sourcelists = repr(self._sourcelists)
-        allow_duplicates = repr(self._allow_duplicates)
-        default_to_implicit_numbering = repr(self._default_to_implicit_numbering)
         # determine class name dynamically so that inherited classes
         # don't have to reimplement __repr__()
         return (
-            f"{self.__class__.__name__}({tags}, {sourcelists}, {allow_duplicates}, "
-            f"{default_to_implicit_numbering}, {self._default_source_number_digits})"
+            f"{self.__class__.__name__}({self._tags!r}, {self._sourcelists!r}, "
+            f"{self._allow_duplicates!r}, {self._default_to_implicit_numbering!r}, "
+            f"{self._default_source_number_digits!r})"
         )
 
     def __contains__(self, location: object) -> bool:

--- a/specfile/spec_parser.py
+++ b/specfile/spec_parser.py
@@ -13,6 +13,7 @@ import rpm
 
 from specfile.context_management import capture_stderr
 from specfile.exceptions import RPMException
+from specfile.formatter import formatted
 from specfile.macros import Macros
 from specfile.sections import Section
 from specfile.tags import Tags
@@ -51,11 +52,9 @@ class SpecParser:
         self.spec = None
         self.tainted = False
 
+    @formatted
     def __repr__(self) -> str:
-        sourcedir = repr(self.sourcedir)
-        macros = repr(self.macros)
-        force_parse = repr(self.force_parse)
-        return f"SpecParser({sourcedir}, {macros}, {force_parse})"
+        return f"SpecParser({self.sourcedir!r}, {self.macros!r}, {self.force_parse!r})"
 
     @contextlib.contextmanager
     def _make_dummy_sources(

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -14,6 +14,7 @@ import rpm
 from specfile.changelog import Changelog, ChangelogEntry
 from specfile.context_management import ContextManager
 from specfile.exceptions import SourceNumberException, SpecfileException
+from specfile.formatter import formatted
 from specfile.macro_definitions import MacroDefinition, MacroDefinitions
 from specfile.macros import Macro, Macros
 from specfile.prep import Prep
@@ -56,13 +57,12 @@ class Specfile:
         )
         self._parser.parse(str(self))
 
+    @formatted
     def __repr__(self) -> str:
-        path = repr(self.path)
-        sourcedir = repr(self._parser.sourcedir)
-        autosave = repr(self.autosave)
-        macros = repr(self._parser.macros)
-        force_parse = repr(self._parser.force_parse)
-        return f"Specfile({path}, {sourcedir}, {autosave}, {macros}, {force_parse})"
+        return (
+            f"Specfile({self.path!r}, {self._parser.sourcedir!r}, {self.autosave!r}, "
+            f"{self._parser.macros!r}, {self._parser.force_parse!r})"
+        )
 
     def __str__(self) -> str:
         return "\n".join(self._lines) + "\n"

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -7,6 +7,7 @@ import re
 from typing import Any, Iterable, List, Optional, SupportsIndex, Union, cast, overload
 
 from specfile.constants import TAG_NAMES, TAGS_WITH_ARG
+from specfile.formatter import formatted
 from specfile.sections import Section
 from specfile.utils import split_conditional_macro_expansion
 
@@ -37,8 +38,9 @@ class Comment:
     def __str__(self) -> str:
         return f"{self.prefix}{self.text}"
 
+    @formatted
     def __repr__(self) -> str:
-        return f"Comment('{self.text}', '{self.prefix}')"
+        return f"Comment({self.text!r}, {self.prefix!r})"
 
 
 class Comments(collections.UserList):
@@ -72,10 +74,9 @@ class Comments(collections.UserList):
             preceding_lines.copy() if preceding_lines is not None else []
         )
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        preceding_lines = repr(self._preceding_lines)
-        return f"Comments({data}, {preceding_lines})"
+        return f"Comments({self.data!r}, {self._preceding_lines!r})"
 
     def __contains__(self, item: object) -> bool:
         if isinstance(item, str):
@@ -237,12 +238,11 @@ class Tag:
             and self._suffix == other._suffix
         )
 
+    @formatted
     def __repr__(self) -> str:
-        comments = repr(self.comments)
-        expanded_value = repr(self._expanded_value)
         return (
-            f"Tag('{self.name}', '{self.value}', {expanded_value}, "
-            f"'{self._separator}', {comments}, '{self._prefix}', '{self._suffix}')"
+            f"Tag({self.name!r}, {self.value!r}, {self._expanded_value!r}, "
+            f"{self._separator!r}, {self.comments!r}, {self._prefix!r}, {self._suffix!r})"
         )
 
     @property
@@ -317,10 +317,9 @@ class Tags(collections.UserList):
             self.data = data.copy()
         self._remainder = remainder.copy() if remainder is not None else []
 
+    @formatted
     def __repr__(self) -> str:
-        data = repr(self.data)
-        remainder = repr(self._remainder)
-        return f"Tags({data}, {remainder})"
+        return f"Tags({self.data!r}, {self._remainder!r})"
 
     @overload
     def __getitem__(self, i: SupportsIndex) -> Tag:

--- a/specfile/utils.py
+++ b/specfile/utils.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 from specfile.constants import ARCH_NAMES
 from specfile.exceptions import SpecfileException, UnterminatedMacroException
+from specfile.formatter import formatted
 from specfile.value_parser import ConditionalMacroExpansion, ValueParser
 
 
@@ -31,8 +32,9 @@ class EVR(collections.abc.Hashable):
             return NotImplemented
         return self._key() == other._key()
 
+    @formatted
     def __repr__(self) -> str:
-        return f"EVR(epoch={self.epoch}, version='{self.version}', release='{self.release}')"
+        return f"EVR(epoch={self.epoch!r}, version={self.version!r}, release={self.release!r})"
 
     def __str__(self) -> str:
         epoch = f"{self.epoch}:" if self.epoch > 0 else ""
@@ -62,10 +64,11 @@ class NEVR(EVR):
     def _key(self) -> tuple:
         return self.name, self.epoch, self.version, self.release
 
+    @formatted
     def __repr__(self) -> str:
         return (
-            f"NEVR(name='{self.name}', epoch={self.epoch}, "
-            f"version='{self.version}', release='{self.release}')"
+            f"NEVR(name={self.name!r}, epoch={self.epoch!r}, "
+            f"version={self.version!r}, release={self.release!r})"
         )
 
     def __str__(self) -> str:
@@ -97,11 +100,12 @@ class NEVRA(NEVR):
     def _key(self) -> tuple:
         return self.name, self.epoch, self.version, self.release, self.arch
 
+    @formatted
     def __repr__(self) -> str:
         return (
-            f"NEVRA(name='{self.name}', epoch={self.epoch}, "
-            f"version='{self.version}', release='{self.release}', "
-            f"arch='{self.arch}')"
+            f"NEVRA(name={self.name!r}, epoch={self.epoch!r}, "
+            f"version={self.version!r}, release={self.release!r}, "
+            f"arch={self.arch!r})"
         )
 
     def __str__(self) -> str:

--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -8,6 +8,7 @@ from string import Template
 from typing import TYPE_CHECKING, List, Optional, Pattern, Set, Tuple
 
 from specfile.exceptions import UnterminatedMacroException
+from specfile.formatter import formatted
 from specfile.macros import Macros
 
 if TYPE_CHECKING:
@@ -28,8 +29,9 @@ class StringLiteral(Node):
     def __init__(self, value: str) -> None:
         self.value = value
 
+    @formatted
     def __repr__(self) -> str:
-        return f"StringLiteral('{self.value}')"
+        return f"StringLiteral({self.value!r})"
 
     def __str__(self) -> str:
         return self.value
@@ -46,10 +48,11 @@ class ShellExpansion(Node):
     def __init__(self, body: str) -> None:
         self.body = body
 
+    @formatted
     def __repr__(self) -> str:
         # determine class name dynamically so that inherited classes
         # don't have to reimplement __repr__()
-        return f"{self.__class__.__name__}('{self.body}')"
+        return f"{self.__class__.__name__}({self.body!r})"
 
     def __str__(self) -> str:
         return f"%({self.body})"
@@ -73,8 +76,9 @@ class MacroSubstitution(Node):
     def __init__(self, body: str) -> None:
         _, self.prefix, self.name = re.split(r"([?!]*)", body, maxsplit=1)
 
+    @formatted
     def __repr__(self) -> str:
-        return f"MacroSubstitution('{self.prefix}{self.name}')"
+        return f"MacroSubstitution({(self.prefix + self.name)!r})"
 
     def __str__(self) -> str:
         return f"%{self.prefix}{self.name}"
@@ -94,9 +98,10 @@ class EnclosedMacroSubstitution(Node):
         self.args: List[str]
         self.name, *self.args = rest.split()
 
+    @formatted
     def __repr__(self) -> str:
         args = (" " + " ".join(self.args)) if self.args else ""
-        return f"EnclosedMacroSubstitution('{self.prefix}{self.name}{args}')"
+        return f"EnclosedMacroSubstitution({(self.prefix + self.name + args)!r})"
 
     def __str__(self) -> str:
         args = (" " + " ".join(self.args)) if self.args else ""
@@ -119,9 +124,11 @@ class ConditionalMacroExpansion(Node):
         _, self.prefix, self.name = re.split(r"([?!]*)", condition, maxsplit=1)
         self.body = body
 
+    @formatted
     def __repr__(self) -> str:
-        body = repr(self.body)
-        return f"ConditionalMacroExpansion('{self.prefix}{self.name}', {body})"
+        return (
+            f"ConditionalMacroExpansion({(self.prefix + self.name)!r}, {self.body!r})"
+        )
 
     def __str__(self) -> str:
         body = "".join(str(n) for n in self.body)
@@ -144,8 +151,9 @@ class BuiltinMacro(Node):
         self.name = name
         self.body = body
 
+    @formatted
     def __repr__(self) -> str:
-        return f"BuiltinMacro('{self.name}', '{self.body}')"
+        return f"BuiltinMacro({self.name!r}, {self.body!r})"
 
     def __str__(self) -> str:
         return f"%{{{self.name}:{self.body}}}"

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import textwrap
+
+import pytest
+
+from specfile.formatter import format_expression
+
+
+@pytest.mark.parametrize(
+    "original, reformatted",
+    [
+        ("func('arg')", "func('arg')"),
+        ("func('arg1', \"arg2\")", "func('arg1', 'arg2')"),
+        ("func('arg1', 'arg\\'2')", "func('arg1', \"arg'2\")"),
+        ("func('arg', kwarg='val')", "func('arg', kwarg='val')"),
+        ("[1,2,3,4]", "[1, 2, 3, 4]"),
+        ("{'key':'val'}", "{'key': 'val'}"),
+        ("<ENUM_ITEM_1: 1>", "<ENUM_ITEM_1: 1>"),
+        (
+            "func1('first argument', True, func2(kwarg={42: ['nested list item 1', "
+            "'nested list item 2', 'nested list item 3']}), 0, indent='    ', "
+            "spec=<rpm.spec object at 0x7fe1ae1a6b30>)",
+            textwrap.dedent(
+                """\
+                func1(
+                    'first argument',
+                    True,
+                    func2(
+                        kwarg={
+                            42: [
+                                'nested list item 1',
+                                'nested list item 2',
+                                'nested list item 3',
+                            ],
+                        },
+                    ),
+                    0,
+                    indent='    ',
+                    spec=<rpm.spec object at 0x7fe1ae1a6b30>,
+                )"""
+            ),
+        ),
+    ],
+)
+def test_format_expression(original, reformatted):
+    assert format_expression(original) == reformatted


### PR DESCRIPTION
I've added a simple expression formatter that should follow `black` formatting style, and `@formatted` decorator to auto-format `__repr__()` in all classes.

Before:
```python
>>> spec.tags().content
Tags([Tag('Name', 'python-specfile', 'python-specfile', ':           ', Comments([], ['%if 0%{?rhel}
== 9', '# RHEL 9 is missing python-flexmock', '%bcond_with tests', '%else', '%bcond_without tests',
'%endif', '', '', '%global desc %{expand:', 'Python library for parsing and manipulating RPM spec
files.', 'Main focus is on modifying existing spec files, any change should result', 'in a minimal
diff.}', '', '']), '', ''), Tag('Version', '0.9.0', '0.9.0', ':        ', Comments([], []), '', ''),
Tag('Release', '1%{?dist}', '1.fc37', ':        ', Comments([], []), '', ''), Tag('Summary', 'A
library for parsing and manipulating RPM spec files', 'A library for parsing and manipulating RPM
spec files', ':        ', Comments([], ['']), '', ''), Tag('License', 'MIT', 'MIT', ':        ',
Comments([], []), '', ''), Tag('URL', 'https://github.com/packit/specfile',
'https://github.com/packit/specfile', ':            ', Comments([], []), '', ''), Tag('Source0',
'%{pypi_source specfile}',
'https://files.pythonhosted.org/packages/source/s/specfile/specfile-0.9.0.tar.gz', ':        ',
Comments([], ['']), '', ''), Tag('BuildArch', 'noarch', 'noarch', ':      ', Comments([], ['']), '',
''), Tag('BuildRequires', 'python%{python3_pkgversion}-devel', 'python3-devel', ':  ', Comments([],
['']), '', '')], ['', ''])

>>> spec.prep().content
Prep(PrepMacros([AutosetupMacro('%autosetup', MacroOptions([Token(<TokenType.DEFAULT: 1>, '-p1'),
Token(<TokenType.WHITESPACE: 2>, ' '), Token(<TokenType.DEFAULT: 1>, '-n'),
Token(<TokenType.WHITESPACE: 2>, ' '), Token(<TokenType.DEFAULT: 1>, 'specfile-%{version}')],
'a:b:cDn:TvNS:p:', {'n': '%{name}-%{version}', 'S': 'patch'}), ' ', '', '', [])], ['# Use packaged
RPM python bindings downstream', "sed -i 's/rpm-py-installer/rpm/' setup.cfg", '', '']))
```

After:
```python
>>> spec.tags().content
Tags(
    [
        Tag(
            'Name',
            'python-specfile',
            'python-specfile',
            ':           ',
            Comments(
                [],
                [
                    '%if 0%{?rhel} == 9',
                    '# RHEL 9 is missing python-flexmock',
                    '%bcond_with tests',
                    '%else',
                    '%bcond_without tests',
                    '%endif',
                    '',
                    '',
                    '%global desc %{expand:',
                    'Python library for parsing and manipulating RPM spec files.',
                    'Main focus is on modifying existing spec files, any change should result',
                    'in a minimal diff.}',
                    '',
                    '',
                ],
            ),
            '',
            '',
        ),
        Tag('Version', '0.9.0', '0.9.0', ':        ', Comments([], []), '', ''),
        Tag(
            'Release',
            '1%{?dist}',
            '1.fc37',
            ':        ',
            Comments([], []),
            '',
            '',
        ),
        ...

>>> spec.prep().content
Prep(
    PrepMacros(
        [
            AutosetupMacro(
                '%autosetup',
                MacroOptions(
                    [
                        Token(<TokenType.DEFAULT: 1>, '-p1'),
                        Token(<TokenType.WHITESPACE: 2>, ' '),
                        Token(<TokenType.DEFAULT: 1>, '-n'),
                        Token(<TokenType.WHITESPACE: 2>, ' '),
                        Token(<TokenType.DEFAULT: 1>, 'specfile-%{version}'),
                    ],
                    'a:b:cDn:TvNS:p:',
                    {'n': '%{name}-%{version}', 'S': 'patch'},
                ),
                ' ',
                '',
                '',
                [],
            ),
        ],
        [
            '# Use packaged RPM python bindings downstream',
            "sed -i 's/rpm-py-installer/rpm/' setup.cfg",
            '',
            '',
        ],
    ),
)
```