### PR TITLE
Add Section.is_script property

### DIFF
--- a/specfile/constants.py
+++ b/specfile/constants.py
@@ -40,6 +40,40 @@ SECTION_NAMES = {
     "sourcelist",
 }
 
+SIMPLE_SCRIPT_SECTIONS = {
+    "conf",
+    "generate_buildrequires",
+    "build",
+    "install",
+    "check",
+    "clean",
+}
+
+SCRIPT_SECTIONS = {
+    "pre",
+    "post",
+    "preun",
+    "postun",
+    "pretrans",
+    "posttrans",
+    "preuntrans",
+    "postuntrans",
+    "verifyscript",
+    "triggerprein",
+    "trigger",
+    "triggerin",
+    "triggerun",
+    "triggerpostun",
+    "filetrigger",
+    "filetriggerin",
+    "filetriggerun",
+    "filetriggerpostun",
+    "transfiletrigger",
+    "transfiletriggerin",
+    "transfiletriggerun",
+    "transfiletriggerpostun",
+}
+
 # valid tag names as defined in build/parsePreamble.c in RPM source
 TAG_NAMES = {
     "name",

--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -5,7 +5,7 @@ import collections
 import re
 from typing import List, Optional, SupportsIndex, Union, cast, overload
 
-from specfile.constants import SECTION_NAMES
+from specfile.constants import SCRIPT_SECTIONS, SECTION_NAMES, SIMPLE_SCRIPT_SECTIONS
 from specfile.formatter import formatted
 
 # name for the implicit "preamble" section
@@ -67,6 +67,12 @@ class Section(collections.UserList):
             return tokens[0].lower()
         name, *rest = tokens
         return name.lower() + "".join(rest)
+
+    @property
+    def is_script(self) -> bool:
+        """Whether the content of the section is a shell script."""
+        normalized_name = self.normalized_id.split()[0]
+        return normalized_name in SCRIPT_SECTIONS | SIMPLE_SCRIPT_SECTIONS
 
     def copy(self) -> "Section":
         return Section(self.id, self.data)

--- a/tests/unit/test_sections.py
+++ b/tests/unit/test_sections.py
@@ -87,3 +87,16 @@ def test_copy_sections():
     sections = Sections([Section("package"), Section("package bar")])
     sections_copy = copy.deepcopy(sections)
     assert sections == sections_copy
+
+
+@pytest.mark.parametrize(
+    "section, is_script",
+    [
+        ("package", False),
+        ("install", True),
+        ("PostUn", True),
+        ("SourceList", False),
+    ],
+)
+def test_is_script(section, is_script):
+    assert Section(section).is_script == is_script


### PR DESCRIPTION
Convenience property to determine if the content of a section is in fact a shell script.