### PR TITLE
Make all classes consistently (deep)copyable

### DIFF
--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -63,6 +63,15 @@ class ChangelogEntry:
             following_lines.copy() if following_lines is not None else []
         )
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ChangelogEntry):
+            return NotImplemented
+        return (
+            self.header == other.header
+            and self.content == other.content
+            and self._following_lines == other._following_lines
+        )
+
     def __str__(self) -> str:
         return f"{self.header}\n" + "\n".join(self.content) + "\n"
 

--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import collections
+import copy
 import datetime
 import re
 from typing import List, Optional, SupportsIndex, Union, overload
@@ -246,6 +247,9 @@ class Changelog(collections.UserList):
                 delete(index)
         else:
             delete(i)
+
+    def copy(self) -> "Changelog":
+        return copy.copy(self)
 
     def filter(
         self, since: Optional[str] = None, until: Optional[str] = None

--- a/specfile/macro_definitions.py
+++ b/specfile/macro_definitions.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import collections
+import copy
 import re
 from typing import List, Optional, SupportsIndex, Tuple, Union, overload
 
@@ -164,7 +165,7 @@ class MacroDefinitions(collections.UserList):
             delete(i)
 
     def copy(self) -> "MacroDefinitions":
-        return MacroDefinitions(self.data, self._remainder)
+        return copy.copy(self)
 
     def get(self, name: str) -> MacroDefinition:
         return self.data[self.find(name)]

--- a/specfile/macro_definitions.py
+++ b/specfile/macro_definitions.py
@@ -26,6 +26,17 @@ class MacroDefinition:
             preceding_lines.copy() if preceding_lines is not None else []
         )
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MacroDefinition):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.body == other.body
+            and self.is_global == other.is_global
+            and self._whitespace == other._whitespace
+            and self._preceding_lines == other._preceding_lines
+        )
+
     @formatted
     def __repr__(self) -> str:
         return (

--- a/specfile/prep.py
+++ b/specfile/prep.py
@@ -62,6 +62,18 @@ class PrepMacro(ABC):
             preceding_lines.copy() if preceding_lines is not None else []
         )
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PrepMacro):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.options == other.options
+            and self._delimiter == other._delimiter
+            and self._prefix == other._prefix
+            and self._suffix == other._suffix
+            and self._preceding_lines == other._preceding_lines
+        )
+
     @formatted
     def __repr__(self) -> str:
         # determine class name dynamically so that inherited classes
@@ -250,6 +262,11 @@ class Prep(collections.abc.Container):
 
     def __init__(self, macros: PrepMacros) -> None:
         self.macros = macros.copy()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Prep):
+            return NotImplemented
+        return self.macros == other.macros
 
     @formatted
     def __repr__(self) -> str:

--- a/specfile/prep.py
+++ b/specfile/prep.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import collections
+import copy
 import re
 from abc import ABC
 from typing import Any, Dict, List, Optional, SupportsIndex, Union, cast, overload
@@ -223,7 +224,7 @@ class PrepMacros(collections.UserList):
         return name in ("setup", "autosetup", "autopatch") or name.startswith("patch")
 
     def copy(self) -> "PrepMacros":
-        return PrepMacros(self.data, self._remainder)
+        return copy.copy(self)
 
     def find(self, name: str) -> int:
         for i, macro in enumerate(self.data):

--- a/specfile/prep.py
+++ b/specfile/prep.py
@@ -13,6 +13,10 @@ from specfile.sections import Section
 from specfile.utils import split_conditional_macro_expansion
 
 
+def valid_prep_macro(name: str) -> bool:
+    return name in ("setup", "autosetup", "autopatch") or name.startswith("patch")
+
+
 class PrepMacro(ABC):
     """
     Class that represents a %prep macro.
@@ -204,7 +208,7 @@ class PrepMacros(collections.UserList):
             delete(i)
 
     def __getattr__(self, name: str) -> PrepMacro:
-        if not self.valid_prep_macro(name):
+        if not valid_prep_macro(name):
             return super().__getattribute__(name)
         try:
             return self.data[self.find(f"%{name}")]
@@ -212,16 +216,12 @@ class PrepMacros(collections.UserList):
             raise AttributeError(name)
 
     def __delattr__(self, name: str) -> None:
-        if not self.valid_prep_macro(name):
+        if not valid_prep_macro(name):
             return super().__delattr__(name)
         try:
             self.__delitem__(self.find(f"%{name}"))
         except ValueError:
             raise AttributeError(name)
-
-    @staticmethod
-    def valid_prep_macro(name: str) -> bool:
-        return name in ("setup", "autosetup", "autopatch") or name.startswith("patch")
 
     def copy(self) -> "PrepMacros":
         return copy.copy(self)
@@ -259,12 +259,12 @@ class Prep(collections.abc.Container):
         return item in self.macros
 
     def __getattr__(self, name: str) -> PrepMacro:
-        if not self.macros.valid_prep_macro(name):
+        if not valid_prep_macro(name):
             return super().__getattribute__(name)
         return getattr(self.macros, name)
 
     def __delattr__(self, name: str) -> None:
-        if not self.macros.valid_prep_macro(name):
+        if not valid_prep_macro(name):
             return super().__delattr__(name)
         return delattr(self.macros, name)
 

--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import collections
+import copy
 import re
 from typing import List, Optional, SupportsIndex, Union, cast, overload
 
@@ -42,9 +43,6 @@ class Section(collections.UserList):
     def __repr__(self) -> str:
         return f"Section({self.id!r}, {self.data!r})"
 
-    def __copy__(self) -> "Section":
-        return Section(self.id, self.data)
-
     @overload
     def __getitem__(self, i: SupportsIndex) -> str:
         pass
@@ -75,7 +73,7 @@ class Section(collections.UserList):
         return normalized_name in SCRIPT_SECTIONS | SIMPLE_SCRIPT_SECTIONS
 
     def copy(self) -> "Section":
-        return Section(self.id, self.data)
+        return copy.copy(self)
 
     def get_raw_data(self) -> List[str]:
         if self.id == PREAMBLE:
@@ -113,9 +111,6 @@ class Sections(collections.UserList):
     def __repr__(self) -> str:
         return f"Sections({self.data!r})"
 
-    def __copy__(self) -> "Sections":
-        return Sections(self.data)
-
     def __contains__(self, id: object) -> bool:
         try:
             # use parent's __getattribute__() so this method can be called from __getattr__()
@@ -150,6 +145,9 @@ class Sections(collections.UserList):
             del self.data[self.find(id)]
         except ValueError:
             raise AttributeError(id)
+
+    def copy(self) -> "Sections":
+        return copy.copy(self)
 
     def get(self, id: str) -> Section:
         return self.data[self.find(id)]

--- a/specfile/sourcelist.py
+++ b/specfile/sourcelist.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 import collections
-from typing import TYPE_CHECKING, List, Optional, SupportsIndex, overload
+import copy
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, SupportsIndex, overload
 
 from specfile.formatter import formatted
 from specfile.macros import Macros
@@ -47,7 +48,19 @@ class SourcelistEntry:
 
     @formatted
     def __repr__(self) -> str:
-        return f"SourcelistEntry({self.location!r}, {self.comments!r})"
+        return (
+            f"SourcelistEntry({self.location!r}, {self.comments!r}, {self._context!r})"
+        )
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "SourcelistEntry":
+        result = self.__class__.__new__(self.__class__)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "_context":
+                continue
+            setattr(result, k, copy.deepcopy(v, memo))
+        result._context = self._context
+        return result
 
     @property
     def expanded_location(self) -> str:
@@ -104,7 +117,7 @@ class Sourcelist(collections.UserList):
             return self.data[i]
 
     def copy(self) -> "Sourcelist":
-        return Sourcelist(self.data, self._remainder)
+        return copy.copy(self)
 
     @classmethod
     def parse(

--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -2,10 +2,22 @@
 # SPDX-License-Identifier: MIT
 
 import collections
+import copy
 import re
 import urllib.parse
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 from specfile.exceptions import DuplicateSourceException
 from specfile.formatter import formatted
@@ -260,8 +272,18 @@ class Sources(collections.abc.MutableSequence):
         return (
             f"{self.__class__.__name__}({self._tags!r}, {self._sourcelists!r}, "
             f"{self._allow_duplicates!r}, {self._default_to_implicit_numbering!r}, "
-            f"{self._default_source_number_digits!r})"
+            f"{self._default_source_number_digits!r}, {self._context!r})"
         )
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "Sources":
+        result = self.__class__.__new__(self.__class__)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "_context":
+                continue
+            setattr(result, k, copy.deepcopy(v, memo))
+        result._context = self._context
+        return result
 
     def __contains__(self, location: object) -> bool:
         items = self._get_items()

--- a/specfile/sources.py
+++ b/specfile/sources.py
@@ -97,6 +97,11 @@ class TagSource(Source):
         self._tag = tag
         self._number = number
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TagSource):
+            return NotImplemented
+        return self._tag == other._tag and self._number == other._number
+
     @formatted
     def __repr__(self) -> str:
         # determine class name dynamically so that inherited classes
@@ -187,6 +192,11 @@ class ListSource(Source):
         self._source = source
         self._number = number
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ListSource):
+            return NotImplemented
+        return self._source == other._source and self._number == other._number
+
     @formatted
     def __repr__(self) -> str:
         # determine class name dynamically so that inherited classes
@@ -264,6 +274,19 @@ class Sources(collections.abc.MutableSequence):
         self._default_to_implicit_numbering = default_to_implicit_numbering
         self._default_source_number_digits = default_source_number_digits
         self._context = context
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Sources):
+            return NotImplemented
+        return (
+            self._tags == other._tags
+            and self._sourcelists == other._sourcelists
+            and self._allow_duplicates == other._allow_duplicates
+            and self._default_to_implicit_numbering
+            == other._default_to_implicit_numbering
+            and self._default_source_number_digits
+            == other._default_source_number_digits
+        )
 
     @formatted
     def __repr__(self) -> str:

--- a/specfile/spec_parser.py
+++ b/specfile/spec_parser.py
@@ -53,6 +53,15 @@ class SpecParser:
         self.spec = None
         self.tainted = False
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SpecParser):
+            return NotImplemented
+        return (
+            self.sourcedir == other.sourcedir
+            and self.macros == other.macros
+            and self.force_parse == other.force_parse
+        )
+
     @formatted
     def __repr__(self) -> str:
         return f"SpecParser({self.sourcedir!r}, {self.macros!r}, {self.force_parse!r})"

--- a/specfile/spec_parser.py
+++ b/specfile/spec_parser.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 import contextlib
+import copy
 import logging
 import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Generator, List, Optional, Set, Tuple
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 
 import rpm
 
@@ -55,6 +56,17 @@ class SpecParser:
     @formatted
     def __repr__(self) -> str:
         return f"SpecParser({self.sourcedir!r}, {self.macros!r}, {self.force_parse!r})"
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "SpecParser":
+        result = self.__class__.__new__(self.__class__)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k in ["spec", "tainted"]:
+                continue
+            setattr(result, k, copy.deepcopy(v, memo))
+        result.spec = None
+        result.tainted = False
+        return result
 
     @contextlib.contextmanager
     def _make_dummy_sources(

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -67,6 +67,16 @@ class Specfile:
         # parse here to fail early on parsing errors
         self._parser.parse(str(self))
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Specfile):
+            return NotImplemented
+        return (
+            self.autosave == other.autosave
+            and self._path == other._path
+            and self._lines == other._lines
+            and self._parser == other._parser
+        )
+
     @formatted
     def __repr__(self) -> str:
         return (

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -36,6 +36,11 @@ class Comment:
         self.text = text
         self.prefix = prefix
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Comment):
+            return NotImplemented
+        return self.text == other.text and self.prefix == other.prefix
+
     def __str__(self) -> str:
         return f"{self.prefix}{self.text}"
 

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import collections
+import copy
 import itertools
 import re
 from typing import Any, Iterable, List, Optional, SupportsIndex, Union, cast, overload
@@ -126,7 +127,7 @@ class Comments(collections.UserList):
                 self.data[i] = item
 
     def copy(self) -> "Comments":
-        return Comments(self.data, self._preceding_lines)
+        return copy.copy(self)
 
     def append(self, item: Union[Comment, str]) -> None:
         if isinstance(item, str):
@@ -403,7 +404,7 @@ class Tags(collections.UserList):
             raise AttributeError(name)
 
     def copy(self) -> "Tags":
-        return Tags(self.data, self._remainder)
+        return copy.copy(self)
 
     def find(self, name: str) -> int:
         for i, tag in enumerate(self.data):

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -16,13 +16,13 @@ from specfile.specfile import Specfile
 
 def test_parse(spec_multiple_sources):
     spec = Specfile(spec_multiple_sources)
-    prep = spec._parser.spec.prep
+    prep = spec.rpm_spec.prep
     # remove all sources
     for path in spec.sourcedir.iterdir():
         if not path.samefile(spec.path):
             path.unlink()
     spec = Specfile(spec_multiple_sources)
-    assert spec._parser.spec.prep == prep
+    assert spec.rpm_spec.prep == prep
 
 
 def test_prep_traditional(spec_traditional):
@@ -212,16 +212,12 @@ def test_set_version_and_release(spec_minimal, version, release):
     with spec.tags() as tags:
         assert tags.version.value == spec.version
         assert tags.release.value == spec.raw_release
-    assert spec._parser.spec.sourceHeader[rpm.RPMTAG_VERSION] == spec.expanded_version
-    assert (
-        spec._parser.spec.sourceHeader[rpm.RPMTAG_RELEASE] == spec.expanded_raw_release
-    )
+    assert spec.rpm_spec.sourceHeader[rpm.RPMTAG_VERSION] == spec.expanded_version
+    assert spec.rpm_spec.sourceHeader[rpm.RPMTAG_RELEASE] == spec.expanded_raw_release
     spec.raw_release = release
     with spec.tags() as tags:
         assert tags.release.value == release
-    assert (
-        spec._parser.spec.sourceHeader[rpm.RPMTAG_RELEASE] == spec.expanded_raw_release
-    )
+    assert spec.rpm_spec.sourceHeader[rpm.RPMTAG_RELEASE] == spec.expanded_raw_release
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
 import datetime
 import subprocess
 
@@ -414,3 +415,17 @@ def test_context_management(spec_autosetup, spec_traditional):
     with spec1.tags() as tags1, spec2.tags() as tags2:
         assert tags1 is not tags2
         assert tags1 == tags2
+
+
+def test_copy(spec_autosetup):
+    spec = Specfile(spec_autosetup)
+    shallow_copy = copy.copy(spec)
+    assert shallow_copy == spec
+    assert shallow_copy is not spec
+    assert shallow_copy._lines is spec._lines
+    assert shallow_copy._parser is spec._parser
+    deep_copy = copy.deepcopy(spec)
+    assert deep_copy == spec
+    assert deep_copy is not spec
+    assert deep_copy._lines is not spec._lines
+    assert deep_copy._parser is not spec._parser

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
 import datetime
 
 import pytest
@@ -263,3 +264,25 @@ def test_get_raw_section_data():
         "- first version",
         "  resolves: #999999999",
     ]
+
+
+def test_copy_changelog():
+    changelog = Changelog(
+        [
+            ChangelogEntry.assemble(
+                datetime.date(2021, 5, 4),
+                "Nikola Forró <nforro@redhat.com>",
+                ["- first version", "  resolves: #999999999"],
+                "0.1-1",
+                append_newline=False,
+            ),
+        ]
+    )
+    shallow_copy = copy.copy(changelog)
+    assert shallow_copy == changelog
+    assert shallow_copy is not changelog
+    assert shallow_copy[0] is changelog[0]
+    deep_copy = copy.deepcopy(changelog)
+    assert deep_copy == changelog
+    assert deep_copy is not changelog
+    assert deep_copy[0] is not changelog[0]

--- a/tests/unit/test_macro_definitions.py
+++ b/tests/unit/test_macro_definitions.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
+
 import pytest
 
 from specfile.macro_definitions import MacroDefinition, MacroDefinitions
@@ -113,3 +115,24 @@ def test_get_raw_data():
         "%define desc(x) Test spec file containing several \\",
         "macro definitions in various formats (%?1)",
     ]
+
+
+def test_copy_macro_definitions():
+    macro_definitions = MacroDefinitions(
+        [
+            MacroDefinition(
+                "commit",
+                "9ab9717cf7d1be1a85b165a8eacb71b9e5831113",
+                True,
+                ("", " ", "      ", ""),
+            ),
+        ],
+    )
+    shallow_copy = copy.copy(macro_definitions)
+    assert shallow_copy == macro_definitions
+    assert shallow_copy is not macro_definitions
+    assert shallow_copy[0] is macro_definitions[0]
+    deep_copy = copy.deepcopy(macro_definitions)
+    assert deep_copy == macro_definitions
+    assert deep_copy is not macro_definitions
+    assert deep_copy[0] is not macro_definitions[0]

--- a/tests/unit/test_prep.py
+++ b/tests/unit/test_prep.py
@@ -1,10 +1,12 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
+
 import pytest
 
 from specfile.macro_options import MacroOptions, Token, TokenType
-from specfile.prep import PatchMacro, Prep, PrepMacros, SetupMacro
+from specfile.prep import AutosetupMacro, PatchMacro, Prep, PrepMacros, SetupMacro
 from specfile.sections import Section
 
 
@@ -169,3 +171,27 @@ def test_prep_get_raw_section_data():
         "%{!?skip_patch2:%patch2 -p2}",
         "",
     ]
+
+
+def test_copy_prep():
+    prep = Prep(
+        PrepMacros(
+            [
+                AutosetupMacro(
+                    AutosetupMacro.CANONICAL_NAME,
+                    MacroOptions([]),
+                    "",
+                ),
+            ],
+        )
+    )
+    shallow_copy = copy.copy(prep)
+    assert shallow_copy == prep
+    assert shallow_copy is not prep
+    assert shallow_copy.macros is prep.macros
+    assert shallow_copy.macros[0] is prep.macros[0]
+    deep_copy = copy.deepcopy(prep)
+    assert deep_copy == prep
+    assert deep_copy is not prep
+    assert deep_copy.macros is not prep.macros
+    assert deep_copy.macros[0] is not prep.macros[0]

--- a/tests/unit/test_sections.py
+++ b/tests/unit/test_sections.py
@@ -84,9 +84,15 @@ def test_parse_invalid_name():
 
 
 def test_copy_sections():
-    sections = Sections([Section("package"), Section("package bar")])
-    sections_copy = copy.deepcopy(sections)
-    assert sections == sections_copy
+    sections = Sections([Section("package", ["Name: test", "Version: 0.1"])])
+    shallow_copy = copy.copy(sections)
+    assert shallow_copy == sections
+    assert shallow_copy is not sections
+    assert shallow_copy[0] is sections[0]
+    deep_copy = copy.deepcopy(sections)
+    assert deep_copy == sections
+    assert deep_copy is not sections
+    assert deep_copy[0] is not sections[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_sourcelist.py
+++ b/tests/unit/test_sourcelist.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
+
 from specfile.sections import Section
 from specfile.sourcelist import Sourcelist, SourcelistEntry
 from specfile.tags import Comment, Comments
@@ -43,3 +45,19 @@ def test_get_raw_section_data():
         "",
         "",
     ]
+
+
+def test_copy_sourcelist():
+    sourcelist = Sourcelist(
+        [
+            SourcelistEntry("tests.tar.xz", Comments([Comment("test suite")], [""])),
+        ],
+    )
+    shallow_copy = copy.copy(sourcelist)
+    assert shallow_copy == sourcelist
+    assert shallow_copy is not sourcelist
+    assert shallow_copy[0] is sourcelist[0]
+    deep_copy = copy.deepcopy(sourcelist)
+    assert deep_copy == sourcelist
+    assert deep_copy is not sourcelist
+    assert deep_copy[0] is not sourcelist[0]

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
+
 import pytest
 from flexmock import flexmock
 
@@ -444,3 +446,22 @@ def test_patches_get_initial_tag_setup(tags, number, index):
         f"Patch{number}", ": "
     )
     assert patches._get_initial_tag_setup(number) == (index, f"Patch{number}", ": ")
+
+
+def test_copy_sources():
+    sources = Sources(
+        Tags([Tag("Name", "test", "test", ": ", Comments())]),
+        [
+            Sourcelist([SourcelistEntry("%{name}-%{version}.tar.gz", Comments())]),
+        ],
+    )
+    shallow_copy = copy.copy(sources)
+    assert shallow_copy == sources
+    assert shallow_copy is not sources
+    assert shallow_copy._tags is sources._tags
+    assert shallow_copy._sourcelists is sources._sourcelists
+    deep_copy = copy.deepcopy(sources)
+    assert deep_copy == sources
+    assert deep_copy is not sources
+    assert deep_copy._tags is not sources._tags
+    assert deep_copy._sourcelists is not sources._sourcelists

--- a/tests/unit/test_spec_parser.py
+++ b/tests/unit/test_spec_parser.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import copy
 from pathlib import Path
 
 import rpm
@@ -28,3 +29,13 @@ def test_spec_parser_do_parse():
     assert spec.sourceHeader[rpm.RPMTAG_SUMMARY] == "Test package"
     assert spec.sourceHeader[rpm.RPMTAG_LICENSE] == "MIT"
     assert spec.prep is None
+
+
+def test_copy_spec_parser():
+    parser = SpecParser(Path("."), [("dist", ".fc35")])
+    shallow_copy = copy.copy(parser)
+    assert shallow_copy == parser
+    assert shallow_copy is not parser
+    deep_copy = copy.deepcopy(parser)
+    assert deep_copy == parser
+    assert deep_copy is not parser

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -158,5 +158,11 @@ def test_copy_tags():
             Tag("Name", "test", "test", ": ", Comments()),
         ]
     )
-    tags_copy = copy.deepcopy(tags)
-    assert tags == tags_copy
+    shallow_copy = copy.copy(tags)
+    assert shallow_copy == tags
+    assert shallow_copy is not tags
+    assert shallow_copy[0] is tags[0]
+    deep_copy = copy.deepcopy(tags)
+    assert deep_copy == tags
+    assert deep_copy is not tags
+    assert deep_copy[0] is not tags[0]


### PR DESCRIPTION
Most classes don't need to implement anything and just work with both `copy()` and `deepcopy()`, only `SpecParser`, `SourcelistEntry` and `Sources` require special handling.

Classes inheriting from `collections.UserList` have to reimplement the `copy()` method, so it returns a shallow copy of the class, in a way similar to how `list.copy()` behaves.

Since `Specfile` can now be copied, it makes sense to make read-only properties writable, so one can adjust attributes of a copy.

It also makes more sense to parse the spec file before access to the underlying `rpm.spec` object or macros, rather than after 
updates of the content.

Fixes #55.

RELEASE NOTES BEGIN

All classes including `Specfile` itself can now be copied using the standard `copy()` and `deepcopy()` functions from `copy` module.

RELEASE NOTES END
