### PR TITLE
Add evr argument to Specfile.add_changelog_entry

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -393,6 +393,7 @@ class Specfile:
         author: Optional[str] = None,
         email: Optional[str] = None,
         timestamp: Optional[Union[datetime.date, datetime.datetime]] = None,
+        evr: Optional[str] = None,
     ) -> None:
         """
         Adds a new %changelog entry. Does nothing if there is no %changelog section
@@ -407,15 +408,19 @@ class Specfile:
             email: E-mail of the author.
             timestamp: Timestamp of the entry.
               Supply `datetime` rather than `date` for extended format.
+            evr: Override the EVR part of the changelog entry.
+              Macros will be expanded automatically. By default, the function
+              determines the appropriate value based on the specfile's current
+              %{epoch}, %{version}, and %{release} values.
         """
         if self.has_autochangelog:
             return
+        if evr is None:
+            evr = "%{?epoch:%{epoch}:}%{version}-%{release}"
         with self.changelog() as changelog:
             if changelog is None:
                 return
-            evr = self.expand(
-                "%{?epoch:%{epoch}:}%{version}-%{release}", extra_macros=[("dist", "")]
-            )
+            evr = self.expand(evr, extra_macros=[("dist", "")])
             if isinstance(entry, str):
                 entry = [entry]
             if timestamp is None:

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -111,15 +111,16 @@ def test_patches(spec_patchlist):
 
 
 @pytest.mark.parametrize(
-    "rpmdev_packager_available, entry, author, email, timestamp, result",
+    "rpmdev_packager_available, entry, author, email, timestamp, evr, result",
     [
-        (False, None, None, None, None, None),
+        (False, None, None, None, None, None, None),
         (
             True,
             "test",
             None,
             None,
             datetime.date(2022, 2, 1),
+            None,
             Section(
                 "changelog",
                 ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
@@ -128,9 +129,46 @@ def test_patches(spec_patchlist):
         (
             True,
             "test",
+            None,
+            None,
+            datetime.date(2022, 2, 1),
+            "%{version}-%{release}",
+            Section(
+                "changelog",
+                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
+            ),
+        ),
+        (
+            True,
+            "test",
+            None,
+            None,
+            datetime.date(2022, 2, 1),
+            "0.1-1",
+            Section(
+                "changelog",
+                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
+            ),
+        ),
+        (
+            True,
+            "test",
+            None,
+            None,
+            datetime.date(2022, 2, 1),
+            "0.2-1.1",
+            Section(
+                "changelog",
+                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.2-1.1", "test"],
+            ),
+        ),
+        (
+            True,
+            "test",
             "Bill Packager",
             None,
             datetime.date(2022, 2, 1),
+            None,
             Section("changelog", ["* Tue Feb 01 2022 Bill Packager - 0.1-1", "test"]),
         ),
         (
@@ -139,6 +177,7 @@ def test_patches(spec_patchlist):
             "Bill Packager",
             "bill@packager.net",
             datetime.date(2022, 2, 1),
+            None,
             Section(
                 "changelog",
                 ["* Tue Feb 01 2022 Bill Packager <bill@packager.net> - 0.1-1", "test"],
@@ -150,6 +189,7 @@ def test_patches(spec_patchlist):
             "Bill Packager",
             "bill@packager.net",
             datetime.datetime(2022, 2, 1, 9, 28, 13),
+            None,
             Section(
                 "changelog",
                 [
@@ -164,6 +204,7 @@ def test_patches(spec_patchlist):
             "Bill Packager",
             "bill@packager.net",
             datetime.datetime(2022, 2, 1, 9, 28, 13),
+            None,
             Section(
                 "changelog",
                 [
@@ -176,7 +217,14 @@ def test_patches(spec_patchlist):
     ],
 )
 def test_add_changelog_entry(
-    spec_minimal, rpmdev_packager_available, entry, author, email, timestamp, result
+    spec_minimal,
+    rpmdev_packager_available,
+    entry,
+    author,
+    email,
+    timestamp,
+    evr,
+    result,
 ):
     if not rpmdev_packager_available:
         flexmock(subprocess).should_receive("check_output").with_args(
@@ -189,9 +237,9 @@ def test_add_changelog_entry(
     spec = Specfile(spec_minimal)
     if not rpmdev_packager_available:
         with pytest.raises(SpecfileException):
-            spec.add_changelog_entry(entry, author, email, timestamp)
+            spec.add_changelog_entry(entry, author, email, timestamp, evr)
     else:
-        spec.add_changelog_entry(entry, author, email, timestamp)
+        spec.add_changelog_entry(entry, author, email, timestamp, evr)
         with spec.sections() as sections:
             assert sections.changelog[: len(result)] == result
 


### PR DESCRIPTION
This allows adding a changelog entry with an evr value that's different than the current specfile's value. This makes it easier to reconstruct a specfile's %changelog based on another source using the higher level interface.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

RELEASE NOTES BEGIN

Add evr argument to Specfile.add_changelog_entry. This allows adding a changelog entry with an evr value that's different than the current specfile's value. This makes it easier to reconstruct a specfile's %changelog based on another source using the higher level interface.

RELEASE NOTES END
