### PR TITLE
Handle single-line sections

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -224,7 +224,7 @@ class Specfile:
             Spec file sections as `Sections` object.
         """
         with self.lines() as lines:
-            sections = Sections.parse(lines)
+            sections = Sections.parse(lines, context=self)
             try:
                 yield sections
             finally:


### PR DESCRIPTION
Fixes #138.

RELEASE NOTES BEGIN

specfile now supports single-line sections where section content is represented by a macro starting with a newline.

RELEASE NOTES END
