### PR TITLE
Add support for modifiable section options

### DIFF
--- a/specfile/constants.py
+++ b/specfile/constants.py
@@ -74,6 +74,17 @@ SCRIPT_SECTIONS = {
     "transfiletriggerpostun",
 }
 
+# valid section option strings taken from build/parseSpec.c, build/parsePreamble.c,
+# build/parseDescription.c, build/parseFiles.c, build/parsePolicies.c and build/parseScript.c
+# in RPM source
+SECTION_OPTIONS = {
+    "package": "n:",
+    "description": "n:l:",
+    "files": "n:f:",
+    "sepolicy": "n:",
+}
+SECTION_OPTIONS.update({s: "n:f:p:P:eq" for s in SCRIPT_SECTIONS})
+
 # valid tag names as defined in build/parsePreamble.c in RPM source
 TAG_NAMES = {
     "name",

--- a/specfile/exceptions.py
+++ b/specfile/exceptions.py
@@ -27,8 +27,8 @@ class MacroRemovalException(SpecfileException):
     """Exception related to failed removal of RPM macros."""
 
 
-class MacroOptionsException(SpecfileException):
-    """Exception related to processing macro options."""
+class OptionsException(SpecfileException):
+    """Exception related to processing options."""
 
 
 class UnterminatedMacroException(SpecfileException):

--- a/specfile/options.py
+++ b/specfile/options.py
@@ -7,7 +7,7 @@ import string
 from enum import Enum, auto
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union, overload
 
-from specfile.exceptions import MacroOptionsException
+from specfile.exceptions import OptionsException
 from specfile.formatter import formatted
 
 
@@ -64,12 +64,12 @@ class Token(collections.abc.Hashable):
 class Positionals(collections.abc.MutableSequence):
     """Class that represents a sequence of positional arguments."""
 
-    def __init__(self, options: "MacroOptions") -> None:
+    def __init__(self, options: "Options") -> None:
         """
         Constructs a `Positionals` object.
 
         Args:
-            options: MacroOptions instance this object is tied with.
+            options: Options instance this object is tied with.
 
         Returns:
             Constructed instance of `Positionals` class.
@@ -207,7 +207,7 @@ class Positionals(collections.abc.MutableSequence):
             self._options._tokens.insert(index, Token(TokenType.WHITESPACE, " "))
 
 
-class MacroOptions(collections.abc.MutableMapping):
+class Options(collections.abc.MutableMapping):
     """
     Class that represents macro options.
 
@@ -226,7 +226,7 @@ class MacroOptions(collections.abc.MutableMapping):
         defaults: Optional[Dict[str, Union[bool, int, str]]] = None,
     ) -> None:
         """
-        Constructs a `MacroOptions` object.
+        Constructs a `Options` object.
 
         Args:
             tokens: List of tokens in an option string.
@@ -237,7 +237,7 @@ class MacroOptions(collections.abc.MutableMapping):
             defaults: Dict specifying default arguments to options.
 
         Returns:
-            Constructed instance of `MacroOptions` class.
+            Constructed instance of `Options` class.
         """
         self._tokens = tokens.copy()
         self.optstring = optstring or ""
@@ -245,7 +245,7 @@ class MacroOptions(collections.abc.MutableMapping):
 
     @formatted
     def __repr__(self) -> str:
-        return f"MacroOptions({self._tokens!r}, {self.optstring!r}, {self.defaults!r})"
+        return f"Options({self._tokens!r}, {self.optstring!r}, {self.defaults!r})"
 
     def __str__(self) -> str:
         return "".join(str(t) for t in self._tokens)
@@ -343,13 +343,13 @@ class MacroOptions(collections.abc.MutableMapping):
         if not self._valid_option(name):
             return super().__setattr__(name, value)
         if self._requires_argument(name) and isinstance(value, bool):
-            raise MacroOptionsException(f"Option -{name} requires an argument.")
+            raise OptionsException(f"Option -{name} requires an argument.")
         if (
             not self._requires_argument(name)
             and not isinstance(value, bool)
             and value is not None
         ):
-            raise MacroOptionsException(f"Option -{name} is a flag.")
+            raise OptionsException(f"Option -{name} is a flag.")
         i, j = self._find_option(name)
         if i is None:
             if value is not None and value is not False:
@@ -472,7 +472,7 @@ class MacroOptions(collections.abc.MutableMapping):
             List of tokens.
 
         Raises:
-            MacroOptionsException if the option string is untokenizable.
+            OptionsException if the option string is untokenizable.
         """
         result = []
         token = ""
@@ -496,7 +496,7 @@ class MacroOptions(collections.abc.MutableMapping):
             if quote:
                 if c == "\\":
                     if not inp:
-                        raise MacroOptionsException("No escaped character")
+                        raise OptionsException("No escaped character")
                     c = inp.pop(0)
                     if c != quote:
                         token += "\\"
@@ -523,11 +523,11 @@ class MacroOptions(collections.abc.MutableMapping):
                 continue
             if c == "\\":
                 if not inp:
-                    raise MacroOptionsException("No escaped character")
+                    raise OptionsException("No escaped character")
                 c = inp.pop(0)
             token += c
         if quote:
-            raise MacroOptionsException("No closing quotation")
+            raise OptionsException("No closing quotation")
         if token:
             result.append(Token(TokenType.DEFAULT, token))
         return result

--- a/specfile/prep.py
+++ b/specfile/prep.py
@@ -8,7 +8,7 @@ from abc import ABC
 from typing import Any, Dict, List, Optional, SupportsIndex, Union, cast, overload
 
 from specfile.formatter import formatted
-from specfile.macro_options import MacroOptions
+from specfile.options import Options
 from specfile.sections import Section
 from specfile.utils import split_conditional_macro_expansion
 
@@ -33,7 +33,7 @@ class PrepMacro(ABC):
     def __init__(
         self,
         name: str,
-        options: MacroOptions,
+        options: Options,
         delimiter: str,
         prefix: Optional[str] = None,
         suffix: Optional[str] = None,
@@ -54,7 +54,7 @@ class PrepMacro(ABC):
             Constructed instance of `PrepMacro` class.
         """
         self.name = name
-        self.options = options
+        self.options = copy.deepcopy(options)
         self._delimiter = delimiter
         self._prefix = prefix or ""
         self._suffix = suffix or ""
@@ -302,7 +302,7 @@ class Prep(collections.abc.Container):
             o: The -o option (output file).
             Z: The -Z option (set UTC times).
         """
-        options = MacroOptions([], PatchMacro.OPTSTRING, PatchMacro.DEFAULTS)
+        options = Options([], PatchMacro.OPTSTRING, PatchMacro.DEFAULTS)
         for k, v in kwargs.items():
             setattr(options, k, v)
         macro = PatchMacro(PatchMacro.CANONICAL_NAME, options, " ")
@@ -375,8 +375,8 @@ class Prep(collections.abc.Container):
                 if not klass:
                     buffer.append(line)
                     continue
-                options = MacroOptions(
-                    MacroOptions.tokenize(option_string),
+                options = Options(
+                    Options.tokenize(option_string),
                     klass.OPTSTRING,
                     klass.DEFAULTS,
                 )

--- a/specfile/spec_parser.py
+++ b/specfile/spec_parser.py
@@ -202,7 +202,7 @@ class SpecParser:
             sources = set()
             # source references: %SOURCEN, %{SOURCEN}, %{S:N}
             source_ref_regex = re.compile(r"%((?P<b>{)?[?!]*SOURCE\d+(?(b)})|{S:\d+})")
-            for tag in Tags.parse(Section("package", content.splitlines())):
+            for tag in Tags.parse(Section("package", data=content.splitlines())):
                 # we can expand macros here because the first non-build parse,
                 # even though it failed, populated the macro context
                 if Macros.expand(tag.value):

--- a/specfile/spec_parser.py
+++ b/specfile/spec_parser.py
@@ -328,4 +328,9 @@ class SpecParser:
         if self.spec:
             # workaround RPM lua tables feature/bug, see above for details
             del self.spec
-        self.spec, self.tainted = self._do_parse(content, extra_macros)
+        try:
+            self.spec, self.tainted = self._do_parse(content, extra_macros)
+        except RPMException:
+            self.spec = None
+            self.tainted = False
+            raise

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -123,7 +123,7 @@ def test_patches(spec_patchlist):
             None,
             Section(
                 "changelog",
-                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
+                data=["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
             ),
         ),
         (
@@ -135,7 +135,7 @@ def test_patches(spec_patchlist):
             "%{version}-%{release}",
             Section(
                 "changelog",
-                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
+                data=["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
             ),
         ),
         (
@@ -147,7 +147,7 @@ def test_patches(spec_patchlist):
             "0.1-1",
             Section(
                 "changelog",
-                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
+                data=["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.1-1", "test"],
             ),
         ),
         (
@@ -159,7 +159,7 @@ def test_patches(spec_patchlist):
             "0.2-1.1",
             Section(
                 "changelog",
-                ["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.2-1.1", "test"],
+                data=["* Tue Feb 01 2022 John Doe <john@doe.net> - 0.2-1.1", "test"],
             ),
         ),
         (
@@ -169,7 +169,9 @@ def test_patches(spec_patchlist):
             None,
             datetime.date(2022, 2, 1),
             None,
-            Section("changelog", ["* Tue Feb 01 2022 Bill Packager - 0.1-1", "test"]),
+            Section(
+                "changelog", data=["* Tue Feb 01 2022 Bill Packager - 0.1-1", "test"]
+            ),
         ),
         (
             True,
@@ -180,7 +182,10 @@ def test_patches(spec_patchlist):
             None,
             Section(
                 "changelog",
-                ["* Tue Feb 01 2022 Bill Packager <bill@packager.net> - 0.1-1", "test"],
+                data=[
+                    "* Tue Feb 01 2022 Bill Packager <bill@packager.net> - 0.1-1",
+                    "test",
+                ],
             ),
         ),
         (
@@ -192,7 +197,7 @@ def test_patches(spec_patchlist):
             None,
             Section(
                 "changelog",
-                [
+                data=[
                     "* Tue Feb 01 09:28:13 UTC 2022 Bill Packager <bill@packager.net> - 0.1-1",
                     "test",
                 ],
@@ -207,7 +212,7 @@ def test_patches(spec_patchlist):
             None,
             Section(
                 "changelog",
-                [
+                data=[
                     "* Tue Feb 01 09:28:13 UTC 2022 Bill Packager <bill@packager.net> - 0.1-1",
                     "line 1",
                     "line 2",

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -140,7 +140,7 @@ def test_parse():
     changelog = Changelog.parse(
         Section(
             "changelog",
-            [
+            data=[
                 "* Mon Nov 21 2022 Nikola Forró <nforro@redhat.com> - 0.3-1",
                 "- this is a formatted",
                 "  changelog entry",

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from specfile.macro_options import MacroOptions, Positionals, Token, TokenType
+from specfile.options import Options, Positionals, Token, TokenType
 
 
 @pytest.mark.parametrize(
@@ -49,7 +49,7 @@ from specfile.macro_options import MacroOptions, Positionals, Token, TokenType
     ],
 )
 def test_positionals_get_items(optstring, tokens, result):
-    options = MacroOptions(tokens, optstring)
+    options = Options(tokens, optstring)
     assert Positionals(options)._get_items() == result
 
 
@@ -95,7 +95,7 @@ def test_positionals_get_items(optstring, tokens, result):
     ],
 )
 def test_positionals_insert(optstring, tokens, index, value, tokens_index, token_type):
-    options = MacroOptions(tokens, optstring)
+    options = Options(tokens, optstring)
     positionals = Positionals(options)
     positionals.insert(index, value)
     assert options._tokens[tokens_index].type == token_type
@@ -110,8 +110,8 @@ def test_positionals_insert(optstring, tokens, index, value, tokens_index, token
         ("a:b:cDn:Tq", "v", False),
     ],
 )
-def test_macro_options_valid_option(optstring, option, valid):
-    options = MacroOptions([], optstring)
+def test_options_valid_option(optstring, option, valid):
+    options = Options([], optstring)
     assert options._valid_option(option) == valid
 
 
@@ -123,8 +123,8 @@ def test_macro_options_valid_option(optstring, option, valid):
         ("a:b:cDn:Tq", "v", None),
     ],
 )
-def test_macro_options_requires_argument(optstring, option, requires_argument):
-    options = MacroOptions([], optstring)
+def test_options_requires_argument(optstring, option, requires_argument):
+    options = Options([], optstring)
     if option in optstring:
         assert options._requires_argument(option) == requires_argument
     else:
@@ -193,8 +193,8 @@ def test_macro_options_requires_argument(optstring, option, requires_argument):
         ),
     ],
 )
-def test_macro_options_find_option(optstring, tokens, option, result):
-    options = MacroOptions(tokens, optstring)
+def test_options_find_option(optstring, tokens, option, result):
+    options = Options(tokens, optstring)
     assert options._find_option(option) == result
 
 
@@ -235,5 +235,5 @@ def test_macro_options_find_option(optstring, tokens, option, result):
         ),
     ],
 )
-def test_macro_options_tokenize(option_string, result):
-    assert MacroOptions.tokenize(option_string) == result
+def test_options_tokenize(option_string, result):
+    assert Options.tokenize(option_string) == result

--- a/tests/unit/test_prep.py
+++ b/tests/unit/test_prep.py
@@ -80,7 +80,7 @@ def test_prep_macros_find():
     ],
 )
 def test_prep_add_patch_macro(lines_before, number, options, lines_after):
-    prep = Prep.parse(Section("prep", lines_before))
+    prep = Prep.parse(Section("prep", data=lines_before))
     prep.add_patch_macro(number, **options)
     assert prep.get_raw_section_data() == lines_after
 
@@ -101,7 +101,7 @@ def test_prep_add_patch_macro(lines_before, number, options, lines_after):
     ],
 )
 def test_prep_remove_patch_macro(lines_before, number, lines_after):
-    prep = Prep.parse(Section("prep", lines_before))
+    prep = Prep.parse(Section("prep", data=lines_before))
     prep.remove_patch_macro(number)
     assert prep.get_raw_section_data() == lines_after
 
@@ -110,7 +110,7 @@ def test_prep_parse():
     prep = Prep.parse(
         Section(
             "prep",
-            [
+            data=[
                 "%setup -q",
                 "# a comment",
                 "%patch0 -p1",

--- a/tests/unit/test_prep.py
+++ b/tests/unit/test_prep.py
@@ -5,7 +5,7 @@ import copy
 
 import pytest
 
-from specfile.macro_options import MacroOptions, Token, TokenType
+from specfile.options import Options, Token, TokenType
 from specfile.prep import AutosetupMacro, PatchMacro, Prep, PrepMacros, SetupMacro
 from specfile.sections import Section
 
@@ -22,7 +22,7 @@ from specfile.sections import Section
 )
 def test_patch_macro_number(name, options, number):
     macro = PatchMacro(
-        name, MacroOptions(MacroOptions.tokenize(options), PatchMacro.OPTSTRING), " "
+        name, Options(Options.tokenize(options), PatchMacro.OPTSTRING), " "
     )
     assert macro.number == number
 
@@ -30,8 +30,8 @@ def test_patch_macro_number(name, options, number):
 def test_prep_macros_find():
     macros = PrepMacros(
         [
-            SetupMacro("%setup", MacroOptions([]), ""),
-            PatchMacro("%patch0", MacroOptions([]), ""),
+            SetupMacro("%setup", Options([]), ""),
+            PatchMacro("%patch0", Options([]), ""),
         ]
     )
     assert macros.find("%patch0") == 1
@@ -132,7 +132,7 @@ def test_prep_get_raw_section_data():
             [
                 SetupMacro(
                     SetupMacro.CANONICAL_NAME,
-                    MacroOptions(
+                    Options(
                         [Token(TokenType.DEFAULT, "-q")],
                         SetupMacro.OPTSTRING,
                         SetupMacro.DEFAULTS,
@@ -141,7 +141,7 @@ def test_prep_get_raw_section_data():
                 ),
                 PatchMacro(
                     PatchMacro.CANONICAL_NAME + "0",
-                    MacroOptions(
+                    Options(
                         [Token(TokenType.DEFAULT, "-p1")],
                         PatchMacro.OPTSTRING,
                         PatchMacro.DEFAULTS,
@@ -151,7 +151,7 @@ def test_prep_get_raw_section_data():
                 ),
                 PatchMacro(
                     PatchMacro.CANONICAL_NAME + "2",
-                    MacroOptions(
+                    Options(
                         [Token(TokenType.DEFAULT, "-p2")],
                         PatchMacro.OPTSTRING,
                         PatchMacro.DEFAULTS,
@@ -179,7 +179,7 @@ def test_copy_prep():
             [
                 AutosetupMacro(
                     AutosetupMacro.CANONICAL_NAME,
-                    MacroOptions([]),
+                    Options([]),
                     "",
                 ),
             ],

--- a/tests/unit/test_sourcelist.py
+++ b/tests/unit/test_sourcelist.py
@@ -12,7 +12,7 @@ def test_parse():
     sourcelist = Sourcelist.parse(
         Section(
             "sourcelist",
-            [
+            data=[
                 "https://example.com/example-0.1.0.tar.xz",
                 "",
                 "# test suite",

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -26,7 +26,7 @@ def test_parse():
     tags = Tags.parse(
         Section(
             "package",
-            [
+            data=[
                 "%global ver_major 1",
                 "%global ver_minor 0",
                 "",
@@ -49,7 +49,7 @@ def test_parse():
         ),
         Section(
             "package",
-            [
+            data=[
                 "",
                 "",
                 "",


### PR DESCRIPTION
For example, the following section:

```rpm-spec
%files doc -f %{name}-doc.files
%doc doc/*.ps doc/*.0 doc/*.html doc/article.txt
```

is represented as:

```python
Section(
    'files',
    Options(
        [
            Token(<TokenType.DEFAULT: 1>, 'doc'),
            Token(<TokenType.WHITESPACE: 2>, ' '),
            Token(<TokenType.DEFAULT: 1>, '-f'),
            Token(<TokenType.WHITESPACE: 2>, ' '),
            Token(<TokenType.DEFAULT: 1>, '%{name}-doc.files'),
        ],
        'n:f:',
        {},
    ),
    ' ',
    '\n',
    ['%doc doc/*.ps doc/*.0 doc/*.html doc/article.txt', ''],
)
```

and can be manipulated like this:

```python
>>> spec = Specfile('fedora/bash.spec')
>>> with spec.sections() as sections:
>>>     # section can still be accessed by ID (name + options)
>>>     section = getattr(sections, "files doc -f %{name}-doc.files")
>>>     section.options.f
'%{name}-doc.files'
>>>     section.options.positional[0]
'doc'
>>>     del section.options.positional[0]
>>>     section.options.n = "bash-doc"
>>>     section.id
'files -f %{name}-doc.files -n bash-doc'
```

RELEASE NOTES BEGIN

Added `Section.options` attribute for convenient manipulation of section options.

RELEASE NOTES END
