### PR TITLE
Avoid parsing the spec file over and over in loops

### DIFF
--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -230,7 +230,12 @@ class Sections(collections.UserList):
 
         def expand(s):
             if context:
-                return context.expand(s)
+                result = context.expand(
+                    s, skip_parsing=getattr(expand, "skip_parsing", False)
+                )
+                # parse only once
+                expand.skip_parsing = True
+                return result
             return Macros.expand(s)
 
         def split_id(line):

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -158,7 +158,10 @@ class Specfile:
         self.path.write_text(str(self))
 
     def expand(
-        self, expression: str, extra_macros: Optional[List[Tuple[str, str]]] = None
+        self,
+        expression: str,
+        extra_macros: Optional[List[Tuple[str, str]]] = None,
+        skip_parsing: bool = False,
     ) -> str:
         """
         Expands an expression in the context of the spec file.
@@ -166,11 +169,15 @@ class Specfile:
         Args:
             expression: Expression to expand.
             extra_macros: Extra macros to be defined before expansion is performed.
+            skip_parsing: Do not parse the spec file before expansion is performed.
+              Defaults to False. Mutually exclusive with extra_macros. Set this to True
+              only if you are certain that the global macro context is up-to-date.
 
         Returns:
             Expanded expression.
         """
-        self._parser.parse(str(self), extra_macros)
+        if not skip_parsing:
+            self._parser.parse(str(self), extra_macros)
         return Macros.expand(expression)
 
     def get_active_macros(self) -> List[Macro]:

--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -312,7 +312,12 @@ class ValueParser:
 
         def expand(s):
             if context:
-                return context.expand(s)
+                result = context.expand(
+                    s, skip_parsing=getattr(expand, "skip_parsing", False)
+                )
+                # parse only once
+                expand.skip_parsing = True
+                return result
             return Macros.expand(s)
 
         def flatten(nodes):

--- a/tests/unit/test_sections.py
+++ b/tests/unit/test_sections.py
@@ -60,7 +60,7 @@ def test_parse():
             "0",
             "%changelog",
         ],
-        context=flexmock(expand=lambda s: "\n" if s == "%{desc}" else ""),
+        context=flexmock(expand=lambda s, **_: "\n" if s == "%{desc}" else ""),
     )
     assert sections[0][0] == "0"
     assert sections[1].id == "description"


### PR DESCRIPTION
This fixes performance regression introduced in 9e1762c5. Before every macro expansion, the spec file is parsed to be sure the global macro context is up-to-date, however, parsing of sections now calls macro expansion in a loop, and that can cause a huge performance hit.

Initially, I tried to implement caching, to parse only if the content of the spec file or some parsing parameters have changed, but then I realized sources affect parsing as well, and it's not even possible to get a list of sources without parsing.