### PR TITLE
Fix expansion of tag values

### DIFF
--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -430,7 +430,6 @@ def test_includes(spec_includes):
     assert not spec.expand("%patches")
     with spec.tags() as tags:
         assert tags.provides.value.startswith("%(")
-        assert tags.provides.expanded_value == "DUMMY-0.1"
     with spec.sections() as sections:
         assert sections.description[0] == "%include %{SOURCE3}"
         assert sections.description[1] == "%(cat %{S:4})"

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -23,7 +23,7 @@ from specfile.tags import Comments, Tag, Tags
     ],
 )
 def test_tag_source_extract_number(tag_name, number):
-    ts = TagSource(Tag(tag_name, "", "", "", Comments()))
+    ts = TagSource(Tag(tag_name, "", "", Comments()))
     assert ts._extract_number() == number
 
 
@@ -74,7 +74,7 @@ def test_tag_source_extract_number(tag_name, number):
 )
 def test_sources_detect_implicit_numbering(tags, default, result):
     sources = Sources(
-        Tags([Tag(t, v, v, ": ", Comments()) for t, v in tags]),
+        Tags([Tag(t, v, ": ", Comments()) for t, v in tags]),
         [],
         default_to_implicit_numbering=default,
     )
@@ -91,7 +91,7 @@ def test_sources_detect_implicit_numbering(tags, default, result):
 )
 def test_sources_get_tag_format(ref_name, ref_separator, number, name, separator):
     sources = Sources(Tags(), [])
-    reference = TagSource(Tag(ref_name, "", "", ref_separator, Comments()))
+    reference = TagSource(Tag(ref_name, "", ref_separator, Comments()))
     assert sources._get_tag_format(reference, number) == (name, separator)
 
 
@@ -103,9 +103,7 @@ def test_sources_get_tag_format(ref_name, ref_separator, number, name, separator
     ],
 )
 def test_sources_get_initial_tag_setup(tags, number, index):
-    sources = Sources(
-        Tags([Tag(t, "test", "test", ": ", Comments()) for t in tags]), []
-    )
+    sources = Sources(Tags([Tag(t, "test", ": ", Comments()) for t in tags]), [])
     assert sources._get_initial_tag_setup(number) == (index, f"Source{number}", ": ")
 
 
@@ -153,9 +151,7 @@ def test_sources_get_initial_tag_setup(tags, number, index):
     ],
 )
 def test_sources_deduplicate_tag_names(tags, deduplicated_tags):
-    sources = Sources(
-        Tags([Tag(t, "test", "test", ": ", Comments()) for t in tags]), []
-    )
+    sources = Sources(Tags([Tag(t, "test", ": ", Comments()) for t in tags]), [])
     sources._deduplicate_tag_names()
     assert [t.name for t in sources._tags] == deduplicated_tags
 
@@ -242,7 +238,7 @@ def test_sources_deduplicate_tag_names(tags, deduplicated_tags):
 )
 def test_sources_insert(tags, sourcelists, index, location, number, cls):
     sources = Sources(
-        Tags([Tag(t, v, v, ": ", Comments()) for t, v in tags]),
+        Tags([Tag(t, v, ": ", Comments()) for t, v in tags]),
         [
             Sourcelist([SourcelistEntry(s, Comments()) for s in sl])
             for sl in sourcelists
@@ -334,7 +330,7 @@ def test_sources_insert(tags, sourcelists, index, location, number, cls):
     ],
 )
 def test_sources_insert_numbered(tags, number, location, index):
-    sources = Sources(Tags([Tag(t, v, v, ": ", Comments()) for t, v in tags]), [])
+    sources = Sources(Tags([Tag(t, v, ": ", Comments()) for t, v in tags]), [])
     if location in [v for t, v in tags if t.startswith(Sources.prefix)]:
         with pytest.raises(SpecfileException):
             sources.insert_numbered(number, location)
@@ -401,13 +397,13 @@ def test_sources_insert_numbered(tags, number, location, index):
     ],
 )
 def test_sources_remove_numbered(tags, sourcelists, number, new_tags, new_sourcelists):
-    tags = Tags([Tag(t, v, v, ": ", Comments()) for t, v in tags])
+    tags = Tags([Tag(t, v, ": ", Comments()) for t, v in tags])
     sourcelists = [
         Sourcelist([SourcelistEntry(s, Comments()) for s in sl]) for sl in sourcelists
     ]
     sources = Sources(tags, sourcelists)
     sources.remove_numbered(number)
-    assert tags == Tags([Tag(t, v, v, ": ", Comments()) for t, v in new_tags])
+    assert tags == Tags([Tag(t, v, ": ", Comments()) for t, v in new_tags])
     assert sourcelists == [
         Sourcelist([SourcelistEntry(s, Comments()) for s in sl])
         for sl in new_sourcelists
@@ -425,7 +421,7 @@ def test_sources_remove_numbered(tags, sourcelists, number, new_tags, new_source
 )
 def test_patches_get_tag_format(ref_name, ref_separator, number, name, separator):
     patches = Patches(Tags(), [])
-    reference = TagSource(Tag(ref_name, "", "", ref_separator, Comments()))
+    reference = TagSource(Tag(ref_name, "", ref_separator, Comments()))
     assert patches._get_tag_format(reference, number) == (name, separator)
 
 
@@ -439,9 +435,7 @@ def test_patches_get_tag_format(ref_name, ref_separator, number, name, separator
     ],
 )
 def test_patches_get_initial_tag_setup(tags, number, index):
-    patches = Patches(
-        Tags([Tag(t, "test", "test", ": ", Comments()) for t in tags]), []
-    )
+    patches = Patches(Tags([Tag(t, "test", ": ", Comments()) for t in tags]), [])
     flexmock(patches).should_receive("_get_tag_format").and_return(
         f"Patch{number}", ": "
     )
@@ -450,7 +444,7 @@ def test_patches_get_initial_tag_setup(tags, number, index):
 
 def test_copy_sources():
     sources = Sources(
-        Tags([Tag("Name", "test", "test", ": ", Comments())]),
+        Tags([Tag("Name", "test", ": ", Comments())]),
         [
             Sourcelist([SourcelistEntry("%{name}-%{version}.tar.gz", Comments())]),
         ],

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -12,9 +12,9 @@ from specfile.tags import Comment, Comments, Tag, Tags
 def test_find():
     tags = Tags(
         [
-            Tag("Name", "test", "test", ": ", Comments()),
-            Tag("Version", "0.1", "0.1", ": ", Comments()),
-            Tag("Release", "1%{?dist}", "1.fc35", ": ", Comments()),
+            Tag("Name", "test", ": ", Comments()),
+            Tag("Version", "0.1", ": ", Comments()),
+            Tag("Release", "1%{?dist}", ": ", Comments()),
         ]
     )
     assert tags.find("version") == 1
@@ -44,47 +44,28 @@ def test_parse():
                 "Requires:          make",
                 "Requires(post):    bash",
                 "",
+                "Provides:          testX = %{version}-%{release}",
+                "Provides:          bundled(superlib) = 2.42.0",
+                "",
                 "%{?fedora:Suggests:          diffutils}",
             ],
-        ),
-        Section(
-            "package",
-            data=[
-                "",
-                "",
-                "",
-                "# this is a test package",
-                "# not to be used in production",
-                "Name:    test",
-                "Version: 1.0",
-                "  # this is a valid comment",
-                "Release: 1.fc35",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "Requires:          make",
-                "Requires(post):    bash",
-                "",
-                "Suggests:          diffutils",
-            ],
-        ),
+        )
     )
     assert tags[0].name == "Name"
     assert tags[0].comments[0].text == "this is a test package"
     assert tags[0].comments[1].text == "not to be used in production"
     assert tags[1].name == "Version"
     assert tags[1].value == "%{ver_major}.%{ver_minor}"
-    assert tags[1].valid
-    assert tags[1].expanded_value == "1.0"
     assert not tags[1].comments
     assert tags.release.comments[0].prefix == "  # "
     assert tags.epoch.name == "Epoch"
-    assert not tags.epoch.valid
     assert tags.requires.value == "make"
     assert "requires(post)" in tags
-    assert tags[-2].name == "Requires(post)"
+    assert tags[-4].name == "Requires(post)"
+    assert tags[-3].name == "Provides"
+    assert tags[-3].value == "testX = %{version}-%{release}"
+    assert tags[-2].name == "Provides"
+    assert tags[-2].value == "bundled(superlib) = 2.42.0"
     assert tags[-1].name == "Suggests"
     assert tags.suggests.value == "diffutils"
 
@@ -95,7 +76,6 @@ def test_get_raw_section_data():
             Tag(
                 "Name",
                 "test",
-                "test",
                 ":    ",
                 Comments(
                     [
@@ -105,22 +85,18 @@ def test_get_raw_section_data():
                     ["%global ver_major 1", "%global ver_minor 0", ""],
                 ),
             ),
-            Tag("Version", "%{ver_major}.%{ver_minor}", "1.0", ": ", Comments()),
+            Tag("Version", "%{ver_major}.%{ver_minor}", ": ", Comments()),
             Tag(
                 "Release",
                 "1%{?dist}",
-                "1.fc35",
                 ": ",
                 Comments([Comment("this is a valid comment", "  # ")]),
             ),
-            Tag("Epoch", "1", "", ":   ", Comments([], ["", "%if 0"])),
-            Tag(
-                "Requires", "make", "make", ":          ", Comments([], ["%endif", ""])
-            ),
-            Tag("Requires(post)", "bash", "bash", ":    ", Comments()),
+            Tag("Epoch", "1", ":   ", Comments([], ["", "%if 0"])),
+            Tag("Requires", "make", ":          ", Comments([], ["%endif", ""])),
+            Tag("Requires(post)", "bash", ":    ", Comments()),
             Tag(
                 "Suggests",
-                "diffutils",
                 "diffutils",
                 ":          ",
                 Comments([], [""]),
@@ -155,7 +131,7 @@ def test_get_raw_section_data():
 def test_copy_tags():
     tags = Tags(
         [
-            Tag("Name", "test", "test", ": ", Comments()),
+            Tag("Name", "test", ": ", Comments()),
         ]
     )
     shallow_copy = copy.copy(tags)


### PR DESCRIPTION
Retrieving expanded values of tags from parsed sections doesn't make sense because it's impossible to undoubtedly match an unparsed tag to a parsed one. The same goes for validity of a tag.

Expand tag values on demand using macro expansion and remove the `valid` property.
