### PR TITLE
Fix a bug in section parsing

### DIFF
--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -263,7 +263,7 @@ class Sections(collections.UserList):
         macro_definitions = MacroDefinitions.parse(lines)
         for md in macro_definitions:
             position = md.get_position(macro_definitions)
-            excluded_lines.append(range(position, position + len(md.get_raw_data())))
+            excluded_lines.append(range(position, position + len(md.body.splitlines())))
         section_id_regexes = [
             re.compile(rf"^%{re.escape(n)}(\s+.*(?<!\\)$|$)", re.IGNORECASE)
             for n in SECTION_NAMES

--- a/tests/unit/test_sections.py
+++ b/tests/unit/test_sections.py
@@ -125,10 +125,14 @@ def test_parse_macro_definitions():
             "",
             "%description -n %{1}",
             "Subpackage %{1}.}",
+            "",
+            "%prep",
+            "%autosetup",
         ]
     )
-    assert len(sections) == 3
+    assert len(sections) == 4
     assert sections[1].id == "package -n test"
+    assert sections[-1].id == "prep"
 
 
 def test_get_raw_data():


### PR DESCRIPTION
Related to #184.

The bug was catched by rebase-helper test suite. We should run it on every specfile PR.

RELEASE NOTES BEGIN

Fixed a bug in section parsing that caused sections to be ignored when there were macro definitions spread across the spec file and not cumulated at the top.

RELEASE NOTES END
