### PR TITLE
Fix tokenization of options

### DIFF
--- a/specfile/options.py
+++ b/specfile/options.py
@@ -512,6 +512,9 @@ class Options(collections.abc.MutableMapping):
                     if not c.isspace():
                         break
                     whitespace += c
+                else:
+                    result.append(Token(TokenType.WHITESPACE, whitespace))
+                    break
                 inp.insert(0, c)
                 result.append(Token(TokenType.WHITESPACE, whitespace))
                 continue

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -233,6 +233,21 @@ def test_options_find_option(optstring, tokens, option, result):
                 Token(TokenType.DOUBLE_QUOTED, '.test "double quotes"'),
             ],
         ),
+        (
+            "-p1 -b .test_whitespace_at_the_end -M 2  ",
+            [
+                Token(TokenType.DEFAULT, "-p1"),
+                Token(TokenType.WHITESPACE, " "),
+                Token(TokenType.DEFAULT, "-b"),
+                Token(TokenType.WHITESPACE, " "),
+                Token(TokenType.DEFAULT, ".test_whitespace_at_the_end"),
+                Token(TokenType.WHITESPACE, " "),
+                Token(TokenType.DEFAULT, "-M"),
+                Token(TokenType.WHITESPACE, " "),
+                Token(TokenType.DEFAULT, "2"),
+                Token(TokenType.WHITESPACE, "  "),
+            ],
+        ),
     ],
 )
 def test_options_tokenize(option_string, result):


### PR DESCRIPTION
Fixes #196.

RELEASE NOTES BEGIN

Fixed infinite loop that occured when section options were followed by whitespace.

RELEASE NOTES END
