### PR TITLE
Get rid of rpm-py-installer

### DIFF
--- a/fedora/python-specfile.spec
+++ b/fedora/python-specfile.spec
@@ -41,8 +41,6 @@ Summary:        %{summary}
 
 %prep
 %autosetup -p1 -n specfile-%{version}
-# Use packaged RPM python bindings downstream
-sed -i 's/rpm-py-installer/rpm/' setup.cfg
 
 
 %generate_buildrequires

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ keywords =
 [options]
 packages = find:
 install_requires =
-    rpm-py-installer
+    rpm
 python_requires = >=3.9
 include_package_data = True
 


### PR DESCRIPTION
Fixes #187.

RELEASE NOTES BEGIN

Specfile no longer depends on rpm-py-installer, it now depends directly on rpm.

RELEASE NOTES END
