### PR TITLE
Fix parsing of tags

### DIFF
--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -493,7 +493,7 @@ class Tags(collections.UserList):
                 )
                 buffer = []
             else:
-                buffer.append(line)
+                buffer.append(prefix + line + suffix)
         return cls(data, buffer)
 
     def get_raw_section_data(self) -> List[str]:

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -27,6 +27,8 @@ def test_parse():
         Section(
             "package",
             data=[
+                "%{?scl:%scl_package scltest}",
+                "",
                 "%global ver_major 1",
                 "%global ver_minor 0",
                 "",
@@ -51,6 +53,7 @@ def test_parse():
             ],
         )
     )
+    assert tags[0].comments._preceding_lines[0] == "%{?scl:%scl_package scltest}"
     assert tags[0].name == "Name"
     assert tags[0].comments[0].text == "this is a test package"
     assert tags[0].comments[1].text == "not to be used in production"
@@ -82,7 +85,13 @@ def test_get_raw_section_data():
                         Comment("this is a test package"),
                         Comment("not to be used in production"),
                     ],
-                    ["%global ver_major 1", "%global ver_minor 0", ""],
+                    [
+                        "%{?scl:%scl_package scltest}",
+                        "",
+                        "%global ver_major 1",
+                        "%global ver_minor 0",
+                        "",
+                    ],
                 ),
             ),
             Tag("Version", "%{ver_major}.%{ver_minor}", ": ", Comments()),
@@ -107,6 +116,8 @@ def test_get_raw_section_data():
         [],
     )
     assert tags.get_raw_section_data() == [
+        "%{?scl:%scl_package scltest}",
+        "",
         "%global ver_major 1",
         "%global ver_minor 0",
         "",


### PR DESCRIPTION
When parsing tags, if there is a conditional macro expansion on a line, the line is split into prefix, content and suffix. If content is a tag, a `Tag` object is created and prefix and suffix are stored within it. But in case the content is not a tag, prefix and suffix are lost. So when reconstructing section data later, the reconstructed line is not the same and that can cause all kinds of issues.

Fix that.

RELEASE NOTES BEGIN

Fixed a bug that broke parsing in case spec file contained conditionalized macro definitions or similar constructs.

RELEASE NOTES END
