### PR TITLE
Parse only if necessary

### DIFF
--- a/specfile/context_management.py
+++ b/specfile/context_management.py
@@ -39,7 +39,7 @@ def capture_stderr() -> Generator[List[bytes], None, None]:
 
 class GeneratorContextManager(contextlib._GeneratorContextManager):
     """
-    Extended contextlib._GeneratorContextManager that provides get() method.
+    Extended contextlib._GeneratorContextManager that provides content property.
     """
 
     def __init__(self, function: Callable) -> None:

--- a/specfile/sections.py
+++ b/specfile/sections.py
@@ -231,12 +231,7 @@ class Sections(collections.UserList):
 
         def expand(s):
             if context:
-                result = context.expand(
-                    s, skip_parsing=getattr(expand, "skip_parsing", False)
-                )
-                # parse only once
-                expand.skip_parsing = True
-                return result
+                return context.expand(s)
             return Macros.expand(s)
 
         def split_id(line):

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -336,6 +336,7 @@ class Specfile:
                     allow_duplicates,
                     default_to_implicit_numbering,
                     default_source_number_digits,
+                    context=self,
                 )
             finally:
                 for section, sourcelist in sourcelists:
@@ -372,6 +373,7 @@ class Specfile:
                     allow_duplicates,
                     default_to_implicit_numbering,
                     default_source_number_digits,
+                    context=self,
                 )
             finally:
                 for section, patchlist in patchlists:

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -64,7 +64,6 @@ class Specfile:
         self._parser = SpecParser(
             Path(sourcedir or self.path.parent), macros, force_parse
         )
-        # parse here to fail early on parsing errors
         self._parser.parse(str(self))
 
     def __eq__(self, other: object) -> bool:
@@ -161,7 +160,6 @@ class Specfile:
         self,
         expression: str,
         extra_macros: Optional[List[Tuple[str, str]]] = None,
-        skip_parsing: bool = False,
     ) -> str:
         """
         Expands an expression in the context of the spec file.
@@ -169,15 +167,11 @@ class Specfile:
         Args:
             expression: Expression to expand.
             extra_macros: Extra macros to be defined before expansion is performed.
-            skip_parsing: Do not parse the spec file before expansion is performed.
-              Defaults to False. Mutually exclusive with extra_macros. Set this to True
-              only if you are certain that the global macro context is up-to-date.
 
         Returns:
             Expanded expression.
         """
-        if not skip_parsing:
-            self._parser.parse(str(self), extra_macros)
+        self._parser.parse(str(self), extra_macros)
         return Macros.expand(expression)
 
     def get_active_macros(self) -> List[Macro]:

--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -312,12 +312,7 @@ class ValueParser:
 
         def expand(s):
             if context:
-                result = context.expand(
-                    s, skip_parsing=getattr(expand, "skip_parsing", False)
-                )
-                # parse only once
-                expand.skip_parsing = True
-                return result
+                return context.expand(s)
             return Macros.expand(s)
 
         def flatten(nodes):


### PR DESCRIPTION
Parsing before every macro expansion etc. is unnecessary and can cause performance issues, because parsing is a really slow operation.

Parse only after a context switch (necessary because all `Specfile` instances share a single global macro context) or if something that affects parsing has actually changed.

Related to https://github.com/rebase-helper/rebase-helper/issues/910.

RELEASE NOTES BEGIN
Parsing the spec file by RPM is now performed only if really necessary, greatly improving performance in certain scenarios.
RELEASE NOTES END