### PR TITLE
Exit with success if the script succeeded but didn't update anything

### DIFF
--- a/.github/workflows/update-constants.yml
+++ b/.github/workflows/update-constants.yml
@@ -28,7 +28,7 @@ jobs:
           python scripts/update_constants.py specfile/constants.py rpm-source-tree/
           case $? in
             0) echo "pr=true" >> $GITHUB_OUTPUT;;
-            100) echo "pr=false" >> $GITHUB_OUTPUT;;
+            100) echo "pr=false" >> $GITHUB_OUTPUT; exit 0;;
             *) exit $?;;
           esac
       - name: Create Pull Request


### PR DESCRIPTION
Exit code 100 means there was no update and there is no need to open a PR, but it makes the action appear as failed. Fix that.