### PR TITLE
Remove dependency on `rpmdev-packager` for guessing clog entry author

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ specfile.set_version_and_release('2.1', preserve_macros=True)
 #### Changelog
 
 ```python
-# adding a new entry, author is determined using rpmdev-packager (if available)
+# adding a new entry, author is automatically determined
+# (using the same heuristics that rpmdev-packager uses) if possible
 specfile.add_changelog_entry('New upstream release 2.1')
 
 # adding a new entry, specifying author and timestamp explicitly

--- a/fedora/python-specfile.spec
+++ b/fedora/python-specfile.spec
@@ -25,6 +25,10 @@ Source0:        %{pypi_source specfile}
 BuildArch:      noarch
 
 BuildRequires:  python%{python3_pkgversion}-devel
+%if %{with tests}
+# tests/unit/test_guess_packager.py
+BuildRequires:  git-core
+%endif
 
 
 %description

--- a/files/install-requirements-pip.yaml
+++ b/files/install-requirements-pip.yaml
@@ -3,10 +3,3 @@
   hosts: all
   tasks:
     - include_tasks: tasks/generic-dnf-requirements.yaml
-    - name: Install deps from PyPI
-      pip:
-        name: "{{ item }}"
-      with_items:
-        - rpm-py-installer
-        - typing-extensions
-      become: true

--- a/files/tasks/generic-dnf-requirements.yaml
+++ b/files/tasks/generic-dnf-requirements.yaml
@@ -6,5 +6,4 @@
       - git
       - dnf-utils
       - python3-pip
-      - rpmdevtools
   become: true

--- a/files/tasks/rpm-deps.yaml
+++ b/files/tasks/rpm-deps.yaml
@@ -1,6 +1,6 @@
 ---
+# Placeholder
 - name: Install runtime RPM dependencies
   dnf:
-    name:
-      - python3-typing-extensions
+    name: []
   become: true

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -1,6 +1,7 @@
 summary:
   Unit & integration tests
 require:
+  - git-core
   - python3-flexmock
   - python3-pytest
   - python3-specfile

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -3,13 +3,12 @@
 
 import copy
 import datetime
-from contextlib import nullcontext
-from unittest.mock import patch
 
 import pytest
 import rpm
 from flexmock import flexmock
 
+import specfile.specfile
 from specfile.exceptions import RPMException, SpecfileException
 from specfile.prep import AutopatchMacro, AutosetupMacro, PatchMacro, SetupMacro
 from specfile.sections import Section
@@ -222,16 +221,14 @@ def test_add_changelog_entry(
     evr,
     result,
 ):
-    mocker = nullcontext()
     if author is None:
-        mocker = patch(
-            "specfile.specfile.guess_packager", return_value="John Doe <john@doe.net>"
-        )
-    with mocker:
-        spec = Specfile(spec_minimal)
-        spec.add_changelog_entry(entry, author, email, timestamp, evr)
-        with spec.sections() as sections:
-            assert sections.changelog[: len(result)] == result
+        flexmock(specfile.specfile).should_receive("guess_packager").and_return(
+            "John Doe <john@doe.net>"
+        ).once()
+    spec = Specfile(spec_minimal)
+    spec.add_changelog_entry(entry, author, email, timestamp, evr)
+    with spec.sections() as sections:
+        assert sections.changelog[: len(result)] == result
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_guess_packager.py
+++ b/tests/unit/test_guess_packager.py
@@ -1,0 +1,130 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+from collections.abc import Iterable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import rpm
+
+from specfile.changelog import guess_packager
+
+
+@pytest.fixture
+def clean_guess_packager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterable[None]:
+    """
+    Ensure a clean environment
+    """
+    # For $RPM_PACKAGER
+    monkeypatch.delenv("RPM_PACKAGER", False)
+    # Make sure git doesn't read existing config
+    monkeypatch.setenv("HOME", "/dev/null")
+    monkeypatch.delenv("XDG_CONFIG_HOME", False)
+    monkeypatch.chdir(tmp_path)
+    # For %packager
+    old = rpm.expandMacro("%packager")
+    with patch("specfile.changelog._getent_name", return_value=""):
+        try:
+            rpm.delMacro("packager")
+            yield
+        finally:
+            if old != "%packager":
+                rpm.addMacro("packager", old)
+
+
+@pytest.fixture
+def set_packager_env(monkeypatch: pytest.MonkeyPatch) -> str:
+    packager = "Patty Packager <patty@packager.me>"
+    monkeypatch.setenv("RPM_PACKAGER", packager)
+    return packager
+
+
+@pytest.fixture
+def set_packager_git(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterable[str]:
+    packager = "Packager, Patty <packager@patty.dev>"
+
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Packager, Patty"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "packager@patty.dev"],
+        check=True,
+        capture_output=True,
+    )
+    return packager
+
+
+@pytest.fixture
+def set_packager_macro() -> Iterable[str]:
+    try:
+        packager = "Patricia Packager"
+        rpm.addMacro("packager", packager)
+        yield packager
+    finally:
+        rpm.delMacro("packager")
+
+
+@pytest.fixture
+def set_packager_passwd() -> Iterable[str]:
+    packager = "Ms. Packager"
+    with patch("specfile.changelog._getent_name", return_value=packager):
+        yield packager
+
+
+def test_guess_packager_env(clean_guess_packager, set_packager_env):
+    assert guess_packager() == set_packager_env
+
+
+def test_guess_packager_macro(clean_guess_packager, set_packager_macro):
+    assert guess_packager() == set_packager_macro
+
+
+def test_guess_packager_git(clean_guess_packager, set_packager_git):
+    assert guess_packager() == set_packager_git
+
+
+def test_guess_packager_passwd(clean_guess_packager, set_packager_passwd):
+    assert guess_packager() == set_packager_passwd
+
+
+def test_guess_packager_pref1(
+    clean_guess_packager,
+    set_packager_env,
+    set_packager_macro,
+    set_packager_git,
+    set_packager_passwd,
+):
+    assert guess_packager() == set_packager_env
+
+
+def test_guess_packager_pref2(
+    clean_guess_packager, set_packager_macro, set_packager_git, set_packager_passwd
+):
+    assert guess_packager() == set_packager_macro
+
+
+def test_guess_packager_pref3(
+    clean_guess_packager, set_packager_git, set_packager_passwd
+):
+    assert guess_packager() == set_packager_git
+
+
+def test_guess_packager_pref4(
+    clean_guess_packager, set_packager_git, set_packager_passwd
+):
+    subprocess.run(["git", "config", "--unset", "user.email"])
+    assert guess_packager() == "Packager, Patty"
+
+def test_guess_packager_empty(clean_guess_packager):
+    """
+    The function should return an empty string if it can't detect the packager
+    """
+    assert guess_packager() == ""


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.


RELEASE NOTES BEGIN

- Add a new `specfile.changelog.guess_packager()` function that uses similar heuristics as `rpmdev-packager` to guess the author to use in an RPM changelog entry.
- The `specfile.Specfile.add_changelog_entry()` method no longer requires `rpmdev-packager` to guess the changelog entry author.

RELEASE NOTES END
