### PR TITLE
Add `Specfile.has_autorelease` property and fix `Specfile.has_autochangelog`

### DIFF
--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -228,7 +228,7 @@ class ValueParser:
                 i += 2
             elif i < len(value) and value[i] in "*#":
                 i += 1
-            return i + 1
+            return i
 
         result: List[Node] = []
         start = 0

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -320,6 +320,26 @@ def test_remove_patches(spec_commented_patches):
         ]
 
 
+@pytest.mark.parametrize(
+    "raw_release, has_autorelease",
+    [
+        ("1%{?dist}", False),
+        ("%{release_number}%{?dist}", False),
+        ("0.27.%{commitdate}git%{shortcommit}%{?dist}", False),
+        ("%autorelease", True),
+        ("%{autorelease}", True),
+        ("%autorelease -b 4 -s %{date}git%{shortcommit}", True),
+        ("%{?autorelease}%{!?autorelease:1%{?dist}}", True),
+        ("0.10.%{date}git%{shortcommit}.%autorelease", True),
+        ("%{obsrel}.%{autorelease}", True),
+    ],
+)
+def test_autorelease(spec_rpmautospec, raw_release, has_autorelease):
+    spec = Specfile(spec_rpmautospec)
+    spec.raw_release = raw_release
+    assert spec.has_autorelease == has_autorelease
+
+
 @pytest.mark.skipif(
     rpm.__version__ < "4.16", reason="%autochangelog requires rpm 4.16 or higher"
 )


### PR DESCRIPTION
Related to https://github.com/packit/packit/issues/1944.

RELEASE NOTES BEGIN

Added `Specfile.has_autorelease` property to detect if a spec file uses the `%autorelease` macro.

RELEASE NOTES END
