### PR TITLE
Specfile.add_changelog: use UTC dates

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -449,7 +449,7 @@ class Specfile:
                 if changelog and changelog[-1].extended_timestamp:
                     timestamp = datetime.datetime.now().astimezone()
                 else:
-                    timestamp = datetime.date.today()
+                    timestamp = datetime.datetime.now(datetime.timezone.utc).date()
             if author is None:
                 author = guess_packager()
                 if not author:


### PR DESCRIPTION
Story time:

fclogr's (a project I'm currently working on that uses specfile) tests broke
tonight; when I wrote the tests, I assumed that specfile behaved like
rpmdevtools and used dates based on UTC instead of my local timezone. I figured
I'd propose that behavior upstream.

---


rpmdev-bumpspec uses UTC time for the short changelog date format [1],
so it'd be best if specfile did the same.

[1] https://pagure.io/rpmdevtools/blob/30eca1b7a06a2df5bbfa3bfd6a4c89c19c6ebd60/f/rpmdev-bumpspec#_192-193

---

RELEASE NOTES BEGIN

The `specfile.Specfile.add_changelog()` method now uses dates based on UTC
instead of the local timezone.

RELEASE NOTES END
