### PR TITLE
Publishing to PyPI with a Trusted Publisher

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Build a source tarball and a binary wheel
         # https://pypa-build.readthedocs.io

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-n-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for trusted publishing
 
     steps:
       - uses: actions/checkout@v3
@@ -25,5 +27,4 @@ jobs:
         # https://github.com/pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
This workflow has been added as a trusted publisher in [PyPI](https://pypi.org/manage/project/specfile/settings/publishing) so adding the `id-token: write` permission and removing the `password: token` is [all we need](https://github.com/marketplace/actions/pypi-publish#trusted-publishing).

See also: https://docs.pypi.org/trusted-publishers