### PR TITLE
Handle multiple %changelog sections

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -16,5 +16,6 @@ SPEC_MACROS = DATA_DIR / "spec_macros"
 SPEC_MULTIPLE_SOURCES = DATA_DIR / "spec_multiple_sources"
 SPEC_COMMENTED_PATCHES = DATA_DIR / "spec_commented_patches"
 SPEC_SHELL_EXPANSIONS = DATA_DIR / "spec_shell_expansions"
+SPEC_CONDITIONALIZED_CHANGELOG = DATA_DIR / "spec_conditionalized_changelog"
 
 SPECFILE = "test.spec"

--- a/tests/data/spec_conditionalized_changelog/test.spec
+++ b/tests/data/spec_conditionalized_changelog/test.spec
@@ -1,0 +1,20 @@
+Name:           test
+Version:        0.1
+Release:        %autorelease
+Summary:        Test package
+
+License:        MIT
+
+
+%description
+Test package
+
+
+%if 0%{?fedora}
+%changelog
+%autochangelog
+%else
+%changelog
+* Mon May 22 2023 Nikola Forró <nforro@redhat.com>
+- Initial package
+%endif

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from tests.constants import (
     SPEC_AUTOPATCH,
     SPEC_AUTOSETUP,
     SPEC_COMMENTED_PATCHES,
+    SPEC_CONDITIONALIZED_CHANGELOG,
     SPEC_INCLUDES,
     SPEC_MACROS,
     SPEC_MINIMAL,
@@ -96,3 +97,10 @@ def spec_shell_expansions(tmp_path):
     destination = tmp_path / "spec_shell_expansions"
     shutil.copytree(SPEC_SHELL_EXPANSIONS, destination)
     return destination / SPECFILE
+
+
+@pytest.fixture(scope="function")
+def spec_conditionalized_changelog(tmp_path):
+    specfile_path = tmp_path / SPECFILE
+    shutil.copyfile(SPEC_CONDITIONALIZED_CHANGELOG / SPECFILE, specfile_path)
+    return specfile_path

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -325,7 +325,7 @@ def test_autorelease(spec_rpmautospec, raw_release, has_autorelease):
 @pytest.mark.skipif(
     rpm.__version__ < "4.16", reason="%autochangelog requires rpm 4.16 or higher"
 )
-def test_autochangelog(spec_rpmautospec):
+def test_autochangelog(spec_rpmautospec, spec_conditionalized_changelog):
     spec = Specfile(spec_rpmautospec)
     assert spec.has_autochangelog
     with spec.changelog() as changelog:
@@ -335,6 +335,17 @@ def test_autochangelog(spec_rpmautospec):
     spec.add_changelog_entry("test")
     with spec.sections() as sections:
         assert sections.changelog == changelog
+    spec = Specfile(spec_conditionalized_changelog)
+    assert spec.has_autochangelog
+    with spec.sections() as sections:
+        changelog = sections.changelog.copy()
+    spec.add_changelog_entry("test")
+    with spec.sections() as sections:
+        changelogs = [s for s in sections if s.normalized_name == "changelog"]
+    assert len(changelogs) == 2
+    assert changelogs[0] == changelog
+    with spec.changelog(changelogs[1]) as changelog:
+        assert changelog[-1].content == ["test"]
 
 
 def test_update_tag(spec_macros):


### PR DESCRIPTION
There can be multiple `%changelog` sections, for example:

```spec
%if 0%{?rhel} < 9 && ! 0%{?fedora}
%changelog
* Mon May 22 2023 Nikola Forró <nforro@redhat.com> - 0.1-1
- Initial package
%else
%changelog
%autochangelog
%endif
```

Make `Specfile.has_autochangelog` consider all of them, and adjust `Specfile.add_changelog_entry()` to update all as well.

Related to https://github.com/packit/packit/issues/1974.

RELEASE NOTES BEGIN

Specfile library now handles multiple `%changelog` sections.

RELEASE NOTES END
