### PR TITLE
Fix tokenization of option strings

### DIFF
--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -248,6 +248,16 @@ def test_options_find_option(optstring, tokens, option, result):
                 Token(TokenType.WHITESPACE, "  "),
             ],
         ),
+        (
+            '-q -n %{name}-%{version}%[%{rc}?"-rc":""]',
+            [
+                Token(TokenType.DEFAULT, "-q"),
+                Token(TokenType.WHITESPACE, " "),
+                Token(TokenType.DEFAULT, "-n"),
+                Token(TokenType.WHITESPACE, " "),
+                Token(TokenType.DEFAULT, '%{name}-%{version}%[%{rc}?"-rc":""]'),
+            ],
+        ),
     ],
 )
 def test_options_tokenize(option_string, result):


### PR DESCRIPTION
Adjust the tokenization algorithm to take into account quotes contained within macro expansions and other expressions.

Notes for reviewers:

The tokenization works as before, but the option string is first parsed into nodes and everything that's not a string literal is treated as a single token.

RELEASE NOTES BEGIN

Fixed a bug in processing options of `%prep` macros. For instance, when a quoted string appeared inside an expression expansion, it could lead to improper parsing, rendering the spec file invalid after accessing the options.

RELEASE NOTES END
