### PR TITLE
Fix Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,20 +1,15 @@
 ---
 packit_instances: ["prod", "stg"]
 
-upstream_package_name: specfile
-downstream_package_name: python-specfile
-
 upstream_project_url: https://github.com/packit/specfile
 issue_repository: https://github.com/packit/specfile
 
 copy_upstream_release_description: true
 
-actions:
-  pre-sync:
-    - python3 plans/git_reference.py
-
 packages:
   specfile:
+    upstream_package_name: specfile
+    downstream_package_name: python-specfile
     specfile_path: &specfile_path fedora/python-specfile.spec
     files_to_sync:
       - *specfile_path
@@ -27,12 +22,16 @@ packages:
       - python3-build
       - python3-setuptools_scm
     actions:
+      pre-sync:
+        - python3 plans/git_reference.py
       create-archive:
         - python3 -m build --sdist --outdir ./fedora/
         - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
       get-current-version: python3 -m setuptools_scm
 
   specfile-epel8:
+    upstream_package_name: specfile
+    downstream_package_name: python-specfile
     specfile_path: &specfile_path_epel8 epel8/python-specfile.spec
     files_to_sync:
       - *specfile_path_epel8
@@ -44,6 +43,8 @@ packages:
     srpm_build_deps:
       - python3-setuptools_scm
     actions:
+      pre-sync:
+        - python3 plans/git_reference.py
       create-archive:
         - python3 setup.py sdist --dist-dir ./epel8/
         - bash -c "ls -1t ./epel8/*.tar.gz | head -n 1"


### PR DESCRIPTION
It turns out it's not possible to define certain keys at the top level, because they are not propagated to packages.