### PR TITLE
Specify a package for downstream jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -159,6 +159,7 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [specfile]
     packit_instances: ["stg"]
     allowed_pr_authors: ["packit-stg", "packit"]
     dist_git_branches:
@@ -168,6 +169,7 @@ jobs:
 
   - job: bodhi_update
     trigger: commit
+    packages: [specfile]
     packit_instances: ["stg"]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
Downstream jobs don't require any package-specific configuration, but not specifying a package leads to the jobs being triggered twice, once per each package. Fix that.