### PR TITLE
make sure %license is SPDX compatible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Red Hat
+Copyright Contributors to the Packit project.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/epel8/python-specfile.spec
+++ b/epel8/python-specfile.spec
@@ -6,7 +6,7 @@ in a minimal diff.}
 
 Name:           python-specfile
 Version:        0.20.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 
 Summary:        A library for parsing and manipulating RPM spec files
 License:        MIT
@@ -63,6 +63,9 @@ rm -rf specfile.egg-info
 
 
 %changelog
+* Fri Aug 04 2023 Tomas Tomecek <ttomecek@redhat.com> - 0.20.2-2
+- Confirm License is SPDX compatible.
+
 * Mon Jul 31 2023 Packit Team <hello@packit.dev> - 0.20.2-1
 - New upstream release 0.20.2
 

--- a/fedora/python-specfile.spec
+++ b/fedora/python-specfile.spec
@@ -14,7 +14,7 @@ in a minimal diff.}
 
 Name:           python-specfile
 Version:        0.20.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 
 Summary:        A library for parsing and manipulating RPM spec files
 License:        MIT
@@ -71,6 +71,9 @@ Summary:        %{summary}
 
 
 %changelog
+* Fri Aug 04 2023 Tomas Tomecek <ttomecek@redhat.com> - 0.20.2-2
+- Confirm License is SPDX compatible.
+
 * Mon Jul 31 2023 Packit Team <hello@packit.dev> - 0.20.2-1
 - New upstream release 0.20.2
 


### PR DESCRIPTION
```
$ askalono crawl LICENSE
LICENSE
License: MIT (original text)
Score: 1.000
```

https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

The changelog should propagate to dist-git as the SPDX migration
initiative tracks 'spdx' string in changelogs.

I'm at the SPDX hackfest right now and the guidance I got about the
LICENSE Copyright line was:
1. it's meaningless and a waste of time to polish
2. only the "copyright" word has a meaning
3. the year is meaningless, hence I dropped it
4. the team name & authors is relevant so I updated it to match 100%
   what we have in the source files

RELEASE NOTES BEGIN

Specfile's license in RPM spec file is now confirmed to be SPDX compatible.

RELEASE NOTES END