### PR TITLE
Remove deepdiff lock and set default testpaths

### DIFF
--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -24,9 +24,7 @@ adjust:
       - how: install
         package: python3-pip
       - how: shell
-        # the version lock on deepdiff can be removed once this is resolved:
-        # https://github.com/seperman/deepdiff/issues/416
-        script: pip3 install flexmock deepdiff==6.3.1
+        script: pip3 install flexmock deepdiff
 
   - when: "distro == rhel-8 or distro == centos-8 or distro == centos-stream-8"
     because: "packit doesn't support EL 8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,3 +54,8 @@ exclude =
 
 [options.package_data]
 * = py.typed
+
+[tool:pytest]
+testpaths =
+    tests/unit
+    tests/integration


### PR DESCRIPTION
The deepdiff bug has been fixed: https://github.com/seperman/deepdiff/commit/410019e2dad5023632a668b454ede6ed42ad2a9d

Testing dependencies only satisfy unit and integration tests, make them the default.

Partially fixes #283.