### PR TITLE
Make modifiable entity groups greedy

### DIFF
--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -425,7 +425,7 @@ class ValueParser:
                     # this group name already exists, make a backreference
                     regex += f"(?P={group})"
                 else:
-                    regex += f"(?P<{group}>.+?)"
+                    regex += f"(?P<{group}>.+)"
                     named_groups.append(group)
                 template += escape(token[2])
             elif token[0] == "v":

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -439,6 +439,15 @@ def test_update_tag(spec_macros):
         assert md.get("package_version", 13).body == "%{mainver}%{?prever:~%{prever}}"
         assert md.get("package_version", 15).body == "3.2.1"
     assert spec.version == "%{package_version}"
+    spec = Specfile(spec_macros)
+    spec.update_tag("Version", "1.2.3.4~rc5")
+    with spec.macro_definitions() as md:
+        assert md.majorver.body == "1.2"
+        assert md.minorver.body == "3"
+        assert md.patchver.body == "4"
+        assert md.mainver.body == "%{majorver}.%{minorver}.%{patchver}"
+        assert md.prever.body == "rc5"
+    assert spec.version == "%{package_version}"
 
 
 def test_multiple_instances(spec_minimal, spec_autosetup):

--- a/tests/unit/test_value_parser.py
+++ b/tests/unit/test_value_parser.py
@@ -76,14 +76,14 @@ def test_parse(value, nodes):
             "%version",
             {"%version": "1.0"},
             ["version"],
-            "^(?P<version>.+?)$",
+            "^(?P<version>.+)$",
             "%version",
         ),
         (
             "%?version",
             {"%?version": "1.0"},
             ["version"],
-            "^(?P<version>.+?)$",
+            "^(?P<version>.+)$",
             "%?version",
         ),
         (
@@ -115,7 +115,7 @@ def test_parse(value, nodes):
                 "%{mainrel}": "2",
             },
             ["prever", "prerpmver", "mainrel"],
-            "^(?P<sub_0>.+?)\\.(?P<mainrel>.+?)\\.(?P<prerpmver>.+?)$",
+            "^(?P<sub_0>.+?)\\.(?P<mainrel>.+)\\.(?P<prerpmver>.+)$",
             "%{?prever:${sub_0}.}%{mainrel}%{?prever:.%{prerpmver}}",
         ),
         (


### PR DESCRIPTION
This effectively makes the first group most greedy, rather than the last. So, with the following in a spec file:

```spec
%global apiver 2.15
%global patchver 3

Version: %{apiver}.%{patchver}
```

calling `spec.update_tag("Version", "2.16.0")`, the `apiver` macro gets assigned the bigger portion of the version string, resulting in:

```spec
%global apiver 2.16
%global patchver 0
```

rather than:

```spec
%global apiver 2
%global patchver 16.0
```

There are cases (in Fedora spec files) where the previous logic makes more sense, but only a handful of them, and none of them using packit.
With the current implementation, it's one or the other, and I believe this makes more sense.

Related to https://github.com/packit/packit/issues/2033