### PR TITLE
Allow to comment out or uncomment a macro definition

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -730,6 +730,7 @@ class Specfile:
                     )
                     for md in macro_definitions
                     if md.valid
+                    and not md.commented_out
                     and not protected_regex.match(md.name)
                     and not md.name.endswith(")")  # skip macro definitions with options
                 ]


### PR DESCRIPTION
Necessary for Packit to be able to comment out or uncomment a pre-release suffix macro definition ([example](https://src.fedoraproject.org/rpms/golang/blob/5ccb908322500645653a1367f8f9bcded7af5574/f/golang.spec#_99)).

Related to https://github.com/packit/packit/issues/2013.

RELEASE NOTES BEGIN

Macro definitions gained a new `commented_out` property indicating that a macro definition is commented out. Another new property, `comment_out_style`, determines if it is achieved by using a `%dnl` (discard next line) directive (e.g. `%dnl %global prerelease beta2`) or by replacing the starting `%` with `#` (e.g. `#global prerelease beta2`).

RELEASE NOTES END
