### PR TITLE
Change trigger type for PyPI publish action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
`released` reacts only to stable releases, `prereleased` reacts to pre-releases, but not those converted from draft, `published` reacts to both.