### PR TITLE
Mark test_macros_reinit as expected to fail on EL9

### DIFF
--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -107,6 +107,10 @@ def test_macros_define():
     }
 
 
+@pytest.mark.xfail(
+    rpm.__version__ == "4.16.1.3",
+    reason="rpm 4.16.1.3 doesn't seem to dump builtin macros",
+)
 def test_macros_reinit():
     Macros.reinit(MacroLevel.BUILTIN)
     assert all(m.level == MacroLevel.BUILTIN for m in Macros.dump())


### PR DESCRIPTION
`rpm -E %dump` on EL9 doesn't list builtin macros so the test fails.