### PR TITLE
Skip the performance test plan on dist-gt PRs

### DIFF
--- a/plans/performance.fmf
+++ b/plans/performance.fmf
@@ -9,3 +9,7 @@ prepare:
     script: pip3 install pytest-fail-slow
   - how: shell
     script: curl --output-dir /tmp -O https://src.fedoraproject.org/rpms/texlive/raw/rawhide/f/texlive.spec
+adjust:
+  - when: "initiator != packit"
+    because: "skip this plan on dist-git pull requests"
+    enabled: false


### PR DESCRIPTION
It was intended to run on upstream PRs only and it fails on EPEL8 because of old curl version. Just skip it.