### PR TITLE
Fix parsing of `%prep` macros

### DIFF
--- a/specfile/prep.py
+++ b/specfile/prep.py
@@ -357,6 +357,10 @@ class Prep(collections.abc.Container):
                     m.group("d"),
                     m.group("o"),
                 )
+                if delimiter == "" and option_string != "":
+                    # delimiter can't be empty unless the match is just base macro with no options
+                    buffer.append(line)
+                    continue
                 prefix += line[: m.start("m")]
                 suffix = line[m.end("o") :] + suffix
                 klass = next(

--- a/tests/unit/test_prep.py
+++ b/tests/unit/test_prep.py
@@ -112,13 +112,15 @@ def test_prep_parse():
             "prep",
             data=[
                 "%setup -q",
-                "# a comment",
+                "# list all patches",
+                "echo %patches",
                 "%patch0 -p1",
                 "%{!?skip_patch2:%patch2 -p2}",
                 "",
             ],
         )
     )
+    assert len(prep.macros) == 3
     assert prep.macros[0].name == "%setup"
     assert prep.macros[0].options.q
     assert prep.macros[1].name == "%patch0"
@@ -147,7 +149,7 @@ def test_prep_get_raw_section_data():
                         PatchMacro.DEFAULTS,
                     ),
                     " ",
-                    preceding_lines=["# a comment"],
+                    preceding_lines=["# list all patches", "echo %patches"],
                 ),
                 PatchMacro(
                     PatchMacro.CANONICAL_NAME + "2",
@@ -166,7 +168,8 @@ def test_prep_get_raw_section_data():
     )
     assert prep.get_raw_section_data() == [
         "%setup -q",
-        "# a comment",
+        "# list all patches",
+        "echo %patches",
         "%patch0 -p1",
         "%{!?skip_patch2:%patch2 -p2}",
         "",


### PR DESCRIPTION
Parsing of `%prep` macros was incorrect. For instance `%patches` macro when used in `%prep` section was wrongly parsed as `%patch` macro. This commit fixes that.

RELEASE NOTES BEGIN

We have fixed an issue in `%prep` section processing. For instance, if the `%patches` macro appeared there, it would have been converted to `%patch es`, causing failure when executing `%prep` later.

RELEASE NOTES END
