### PR TITLE
Fix parsing of sections and tags from RPM sources

### DIFF
--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -8,7 +8,7 @@ prepare:
     copr: packit/packit-dev
   # make sure the Copr repo has higher priority than TF Tag Repository
   - how: shell
-    script: dnf -y config-manager --save --setopt="*:packit:packit-dev.priority=5"
+    script: sed -i -n '/^priority=/!p;$apriority=5' /etc/yum.repos.d/*:packit:packit-dev.repo
 
 adjust:
   - when: "how == integration"


### PR DESCRIPTION
The definitions have been changed in https://github.com/rpm-software-management/rpm/commit/1296ea93f83e8704c0a1dc9a70ac111b48c6df61.