### PR TITLE
Improve compatibility with rpm 4.20alpha

### DIFF
--- a/tests/data/spec_macros/test.spec
+++ b/tests/data/spec_macros/test.spec
@@ -40,9 +40,9 @@ Test package
 %prep
 %setup -q -n %{name}-%{version}
 %setup -c -T -D -b 1
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
+%patch -P0 -p1
+%patch -P1 -p1
+%patch -P2 -p1
 
 
 %changelog

--- a/tests/data/spec_traditional/test.spec
+++ b/tests/data/spec_traditional/test.spec
@@ -17,9 +17,9 @@ Test package
 
 %prep
 %setup -q
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
+%patch -P0 -p1
+%patch -P1 -p1
+%patch -P2 -p1
 
 
 %changelog

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -41,12 +41,13 @@ def test_prep_traditional(spec_traditional):
         assert len([m for m in prep.macros if isinstance(m, PatchMacro)]) == 2
         prep.add_patch_macro(0, p=2, b=".test")
         assert len(prep.macros) == 4
-        assert prep.patch0.options.p == 2
-        assert prep.patch0.options.b == ".test"
-        prep.patch0.options.b = ".test2"
-        prep.patch0.options.E = True
+        assert prep.macros[1].options.positional == [0]
+        assert prep.macros[1].options.p == 2
+        assert prep.macros[1].options.b == ".test"
+        prep.macros[1].options.b = ".test2"
+        prep.macros[1].options.E = True
     with spec.sections() as sections:
-        assert sections.prep[1] == "%patch0 -p2 -b .test2 -E"
+        assert sections.prep[1] == "%patch 0 -p2 -b .test2 -E"
 
 
 def test_prep_autosetup(spec_autosetup):


### PR DESCRIPTION
rpm 4.20alpha (now in rawhide) obsoletes `%patchN` macros and spec files containing them are unparseable. Stop using such macros in integration tests and add support for the `%patch N` variant.

RELEASE NOTES BEGIN

Improved compatibility with RPM 4.20 (alpha version is currently in Fedora Rawhide).

RELEASE NOTES END
