### PR TITLE
Test EPEL 8 builds on RHEL 8 compose

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -136,8 +136,19 @@ jobs:
     trigger: pull_request
     packages: [specfile-epel8]
     tmt_plan: "smoke|full"
+    use_internal_tf: true
     targets:
-      - epel-8
+      epel-8:
+        distros: [RHEL-8]
+    # enable EPEL
+    tf_extra_params:
+      environments:
+        - kickstart:
+            post-install: |
+              %post --log=/dev/console
+              set -x
+              dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+              %end
 
   - job: tests
     trigger: pull_request

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -2,3 +2,9 @@ summary:
   Unit & integration tests
 discover+:
   filter: tier:1
+adjust:
+  - when: "distro == rhel-8"
+    because: "only platform-python is installed on RHEL 8 by default"
+    prepare+:
+      - how: install
+        package: python3

--- a/plans/smoke.fmf
+++ b/plans/smoke.fmf
@@ -2,3 +2,9 @@ summary:
   Basic smoke test
 discover+:
   filter: tier:0
+adjust:
+  - when: "distro == rhel-8"
+    because: "only platform-python is installed on RHEL 8 by default"
+    prepare+:
+      - how: install
+        package: python3


### PR DESCRIPTION
copr-rpmbuild still builds against EPEL 8 and depends on specfile so we can't drop the support.
Use RHEL 8 compose to test EPEL 8 builds.