### PR TITLE
Avoid updating entity value if the entity is referenced from the new value

### DIFF
--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -407,6 +407,10 @@ def test_update_tag(spec_macros):
     assert spec.raw_release == "%{release}"
     with spec.macro_definitions() as md:
         assert md.release.body == "2%{?dist}"
+    spec.update_tag("Release", "%release")
+    assert spec.raw_release == "%release"
+    with spec.macro_definitions() as md:
+        assert md.release.body == "2%{?dist}"
     spec.update_tag(
         "Source0",
         "https://example.com/archived_releases/test/v6.0.0/test-v6.0.0.tar.xz",


### PR DESCRIPTION
Consider the folowing excerpt from a spec file:

```rpm-spec
%global rel 1%{?dist}

Release: %{rel}
```

Previously, calling `Specfile.update_tag("Release", "%rel")` resulted in the macro definition being updated to `%global rel %rel`, making the spec file invalid. After this change, the macro definition stays unchanged and the tag is updated to `Release: %rel`.