### PR TITLE
drop python<3=3.7 support

### DIFF
--- a/specfile/changelog.py
+++ b/specfile/changelog.py
@@ -400,15 +400,13 @@ def guess_packager() -> str:
     if shutil.which("git"):
         email = subprocess.run(
             ["git", "config", "user.email"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         fullname = subprocess.run(
             ["git", "config", "user.name"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
     if not fullname:
         fullname = _getent_name()

--- a/tests/unit/test_guess_packager.py
+++ b/tests/unit/test_guess_packager.py
@@ -45,19 +45,16 @@ def set_packager_git(monkeypatch: MonkeyPatch, tmp_path: Path) -> str:
 
     monkeypatch.chdir(tmp_path)
     subprocess.run(
-        ["git", "init", "."], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
+        ["git", "init", "."], check=True, capture_output=True)
     subprocess.run(
         ["git", "config", "user.name", "Packager, Patty"],
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.email", "packager@patty.dev"],
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
     return packager
 


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
