### PR TITLE
Implement `Specfile.bump_release()` method

### DIFF
--- a/tests/unit/test_specfile.py
+++ b/tests/unit/test_specfile.py
@@ -32,3 +32,31 @@ def test_split_raw_release(raw_release, release, dist, minorbump):
 )
 def test_get_updated_release(raw_release, release, result):
     assert Specfile._get_updated_release(raw_release, release) == result
+
+
+@pytest.mark.parametrize(
+    "release, bumped_release",
+    [
+        ("1%{?dist}", "2%{?dist}"),
+        ("0.1%{?dist}", "0.2%{?dist}"),
+        ("%release_func 26", "%release_func 27"),
+        ("0.24.rc1%{?dist}", "0.25.rc1%{?dist}"),
+        ("0.2.%{prerel}%{?dist}", "0.3.%{prerel}%{?dist}"),
+        (
+            "0.8.%{commitdate}%{shortcommit}%{?dist}",
+            "0.9.%{commitdate}%{shortcommit}%{?dist}",
+        ),
+        (
+            "3.%{git_date}git%{git_commit_short}%{?dist}",
+            "4.%{git_date}git%{git_commit_short}%{?dist}",
+        ),
+        ("1%{?rcrel}%{?dist}.1", "1%{?rcrel}%{?dist}.2"),
+        (
+            "%{?beta_ver:0.}%{fedora_rel}%{?beta_ver:.%beta_ver}%{?dist}%{flagrel}%{?extrarel}",
+            "%{?beta_ver:0.}%{fedora_rel}%{?beta_ver:.%beta_ver}%{?dist}%{flagrel}%{?extrarel}.1",
+        ),
+        ("4.rc2%{?dist}", "4.rc2%{?dist}.1"),
+    ],
+)
+def test_bump_release_string(release, bumped_release):
+    assert Specfile._bump_release_string(release) == bumped_release


### PR DESCRIPTION
Fixes #364.

RELEASE NOTES BEGIN

It is now possible to bump a release in a manner similar to `rpmdev-bumpspec` using `Specfile.bump_release()` method.

RELEASE NOTES END
