### PR TITLE
Fix parsing of conditions

### DIFF
--- a/specfile/conditions.py
+++ b/specfile/conditions.py
@@ -137,18 +137,19 @@ def process_conditions(
             branches[-1] = not branches[-1]
         else:
             result.append((line, branches[-1]))
-        expression = m.group("expr")
-        if expression:
-            if m.group("end") == "\\":
-                expression += "\\"
-            while expression.endswith("\\") and indexed_lines:
-                _, line = indexed_lines.pop(0)
-                result.append((line, branches[-1]))
-                expression = expression[:-1] + line
+        if keyword.startswith("%if") or keyword.startswith("%elif"):
+            expression = m.group("expr")
+            if expression:
+                if m.group("end") == "\\":
+                    expression += "\\"
+                while expression.endswith("\\") and indexed_lines:
+                    _, line = indexed_lines.pop(0)
+                    result.append((line, branches[-1]))
+                    expression = expression[:-1] + line
             branch = (
                 False
                 if not branches[-1]
-                else resolve_expression(keyword, expression, context)
+                else resolve_expression(keyword, expression or "0", context)
             )
             if keyword.startswith("%el"):
                 branches[-1] = branch

--- a/specfile/conditions.py
+++ b/specfile/conditions.py
@@ -134,7 +134,8 @@ def process_conditions(
             branches.pop()
         elif keyword.startswith("%el"):
             result.append((line, branches[-2]))
-            branches[-1] = not branches[-1]
+            if branches[-2]:
+                branches[-1] = not branches[-1]
         else:
             result.append((line, branches[-1]))
         if keyword.startswith("%if") or keyword.startswith("%elif"):

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -53,6 +53,8 @@ from specfile.macros import Macros
                 "BuildRequires: libX11-devel",
                 "%if 0%{?fedora}",
                 "Requires: desktop-file-utils",
+                "%else",
+                "Requires: gnome-desktop",
                 "%endif",
                 "BuildRequires: libXext-devel",
                 "%else",
@@ -64,6 +66,8 @@ from specfile.macros import Macros
             ],
             [
                 True,
+                False,
+                False,
                 False,
                 False,
                 False,

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -82,6 +82,27 @@ from specfile.macros import Macros
                 else "1" if expr == "%{expr:0%{?fedora}}" else expr
             ),
         ),
+        (
+            [
+                "%if %{bcond_default_lto}",
+                "%bcond_without lto",
+                "%else",
+                "%bcond_with lto",
+                "%endif",
+            ],
+            [
+                True,
+                False,
+                True,
+                True,
+                True,
+            ],
+            lambda expr: (
+                ""
+                if expr == "%{bcond_default_lto}"
+                else "0" if expr == "%{expr:0}" else expr
+            ),
+        ),
     ],
 )
 def test_process_conditions(lines, validity, expand_func):


### PR DESCRIPTION
After https://github.com/packit/specfile/commit/157a62b92612c6d2294724c77d9df6d12823dcb9 conditional expressions are parsed after macro expansion, which means that the actual expression can be empty. Account for that.

Fixes https://github.com/packit/specfile/issues/403.
