### PR TITLE
Handle multi-line tag values

### DIFF
--- a/specfile/macro_definitions.py
+++ b/specfile/macro_definitions.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union, overload
 from specfile.conditions import process_conditions
 from specfile.formatter import formatted
 from specfile.types import SupportsIndex
-from specfile.utils import UserList
+from specfile.utils import UserList, count_brackets
 
 if TYPE_CHECKING:
     from specfile.specfile import Specfile
@@ -302,35 +302,6 @@ class MacroDefinitions(UserList[MacroDefinition]):
                 return line, True
             else:
                 return line
-
-        def count_brackets(s):
-            bc = pc = 0
-            chars = list(s)
-            while chars:
-                c = chars.pop(0)
-                if c == "\\" and chars:
-                    chars.pop(0)
-                    continue
-                if c == "%" and chars:
-                    c = chars.pop(0)
-                    if c == "{":
-                        bc += 1
-                    elif c == "(":
-                        pc += 1
-                    continue
-                if c == "{" and bc > 0:
-                    bc += 1
-                    continue
-                if c == "}" and bc > 0:
-                    bc -= 1
-                    continue
-                if c == "(" and pc > 0:
-                    pc += 1
-                    continue
-                if c == ")" and pc > 0:
-                    pc -= 1
-                    continue
-            return bc, pc
 
         md_regex = re.compile(
             r"""

--- a/specfile/utils.py
+++ b/specfile/utils.py
@@ -254,6 +254,45 @@ def get_filename_from_location(location: str) -> str:
     return location[slash + 1 :].split("=")[-1]
 
 
+def count_brackets(string: str) -> Tuple[int, int]:
+    """
+    Counts non-pair brackets in %{...} and %(...) expressions appearing in the given string.
+
+    Args:
+        string: Input string.
+
+    Returns:
+        The count of non-pair curly braces and the count of non-pair parentheses.
+    """
+    bc = pc = 0
+    chars = list(string)
+    while chars:
+        c = chars.pop(0)
+        if c == "\\" and chars:
+            chars.pop(0)
+            continue
+        if c == "%" and chars:
+            c = chars.pop(0)
+            if c == "{":
+                bc += 1
+            elif c == "(":
+                pc += 1
+            continue
+        if c == "{" and bc > 0:
+            bc += 1
+            continue
+        if c == "}" and bc > 0:
+            bc -= 1
+            continue
+        if c == "(" and pc > 0:
+            pc += 1
+            continue
+        if c == ")" and pc > 0:
+            pc -= 1
+            continue
+    return bc, pc
+
+
 def split_conditional_macro_expansion(value: str) -> Tuple[str, str, str]:
     """
     Splits conditional macro expansion into its body and prefix and suffix of it.

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -43,6 +43,11 @@ def test_parse():
                 "Epoch:   1",
                 "%endif",
                 "",
+                "License: %{shrink:",
+                "             MIT AND",
+                "             (MIT OR Apache-2.0)",
+                "          }",
+                "",
                 "Requires:          make ",
                 "Requires(post):    bash",
                 "",
@@ -62,6 +67,13 @@ def test_parse():
     assert not tags[1].comments
     assert tags.release.comments[0].prefix == "  # "
     assert tags.epoch.name == "Epoch"
+    assert tags[-6].name == "License"
+    assert (
+        tags[-6].value == "%{shrink:\n"
+        "             MIT AND\n"
+        "             (MIT OR Apache-2.0)\n"
+        "          }"
+    )
     assert tags.requires.value == "make"
     assert "requires(post)" in tags
     assert tags[-4].name == "Requires(post)"
@@ -103,10 +115,19 @@ def test_get_raw_section_data():
             ),
             Tag("Epoch", "1", ":   ", Comments([], ["", "%if 0"])),
             Tag(
+                "License",
+                "%{shrink:\n"
+                "             MIT AND\n"
+                "             (MIT OR Apache-2.0)\n"
+                "          }",
+                ": ",
+                Comments([], ["%endif", ""]),
+            ),
+            Tag(
                 "Requires",
                 "make",
                 ":          ",
-                Comments([], ["%endif", ""]),
+                Comments([], [""]),
                 True,
                 "",
                 " ",
@@ -140,6 +161,11 @@ def test_get_raw_section_data():
         "%if 0",
         "Epoch:   1",
         "%endif",
+        "",
+        "License: %{shrink:",
+        "             MIT AND",
+        "             (MIT OR Apache-2.0)",
+        "          }",
         "",
         "Requires:          make ",
         "Requires(post):    bash",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from specfile.utils import EVR, NEVR, NEVRA, get_filename_from_location
+from specfile.utils import EVR, NEVR, NEVRA, count_brackets, get_filename_from_location
 
 
 @pytest.mark.parametrize(
@@ -30,6 +30,23 @@ from specfile.utils import EVR, NEVR, NEVRA, get_filename_from_location
 )
 def test_get_filename_from_location(location, filename):
     assert get_filename_from_location(location) == filename
+
+
+@pytest.mark.parametrize(
+    "string, count",
+    [
+        ("", (0, 0)),
+        ("%macro", (0, 0)),
+        ("%{macro}", (0, 0)),
+        ("%{{macro}}", (0, 0)),
+        ("%{{macro}", (1, 0)),
+        ("%{macro:", (1, 0)),
+        ("%(echo %{v}", (0, 1)),
+        ("%(echo %{v} | cut -d. -f3)", (0, 0)),
+    ],
+)
+def test_count_brackets(string, count):
+    assert count_brackets(string) == count
 
 
 def test_EVR_compare():


### PR DESCRIPTION
Fixes #410.

RELEASE NOTES BEGIN

specfile can now handle multi-line tag values (enclosed in a macro body, e.g. `%shrink`).

RELEASE NOTES END
