### PR TITLE
Make NEVR and NEVRA classes hashable

### DIFF
--- a/specfile/utils.py
+++ b/specfile/utils.py
@@ -98,6 +98,9 @@ class NEVR(EVR):
     def _key(self) -> tuple:
         return self.name, self.epoch, self.version, self.release
 
+    def __hash__(self) -> int:
+        return hash(self._key())
+
     def __lt__(self, other: object) -> bool:
         if type(other) is not self.__class__:
             return NotImplemented
@@ -171,6 +174,9 @@ class NEVRA(NEVR):
 
     def _key(self) -> tuple:
         return self.name, self.epoch, self.version, self.release, self.arch
+
+    def __hash__(self) -> int:
+        return hash(self._key())
 
     def __lt__(self, other: object) -> bool:
         if type(other) is not self.__class__:


### PR DESCRIPTION
It turns out `__hash__()` is not implicitly inherited.

Related to https://github.com/packit/packit-service/issues/2497.