### PR TITLE
Allow building specfile in CentOS Stream without EPEL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     importlib-metadata;python_version<"3.8"
     dataclasses;python_version<"3.7"
     rpm
-    typing-extensions
+    typing-extensions;python_version<"3.8"
 python_requires = >=3.6
 include_package_data = True
 

--- a/specfile/types.py
+++ b/specfile/types.py
@@ -3,10 +3,12 @@
 
 import abc
 
-from typing_extensions import Protocol
+try:
+    from typing import SupportsIndex
+except ImportError:
+    # define our own SupportsIndex type for older version of typing (Python 3.7 and older)
+    from typing_extensions import Protocol
 
-
-# define our own SupportsIndex type for older version of typing_extensions (EL 8)
-class SupportsIndex(Protocol, metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def __index__(self) -> int: ...
+    class SupportsIndex(Protocol, metaclass=abc.ABCMeta):  # type: ignore [no-redef]
+        @abc.abstractmethod
+        def __index__(self) -> int: ...


### PR DESCRIPTION
CentOS Stream does not have EPEL packages in CBS Koji.
Package typing-extensions is not available.