### PR TITLE
ft: Instantiate Specfile from strings or file-like objects

### DIFF
--- a/specfile/types.py
+++ b/specfile/types.py
@@ -12,3 +12,12 @@ except ImportError:
     class SupportsIndex(Protocol, metaclass=abc.ABCMeta):  # type: ignore [no-redef]
         @abc.abstractmethod
         def __index__(self) -> int: ...
+
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
+
+
+EncodingArgs = TypedDict("EncodingArgs", {"encoding": str, "errors": str})


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation.

Fixes #206 
Fixes #248 

RELEASE NOTES BEGIN

- Added support for creating Specfile instances from file objects and strings.

RELEASE NOTES END
