### PR TITLE
Make the specfile list a one-liner that is parsed correctly

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,11 +23,7 @@ jobs:
         uses: packit/prepare-release@v3
         with:
           version: ${{ inputs.version }}
-          specfiles: >
-            fedora/python-specfile.spec,
-            epel8/python-specfile.spec,
-            epel10/python-specfile.spec,
-            centos-integration-sig/python-specfile.spec
+          specfiles: fedora/python-specfile.spec,epel8/python-specfile.spec,epel10/python-specfile.spec,centos-integration-sig/python-specfile.spec
           prerelease_suffix_pattern: "([.\\-_]?)(a(lpha)?|b(eta)?|r?c|pre(view)?)([.\\-_]?\\d+)?"
           prerelease_suffix_macro: prerelease
       - name: Create Pull Request


### PR DESCRIPTION
Extra whitespaces [did](https://github.com/packit/specfile/actions/runs/13852984599/job/38763637618) not work in the prepare-release script.