### PR TITLE
Reopen named files also before saving

### DIFF
--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -26,6 +26,8 @@ adjust:
       - how: shell
         script: pip3 install build 'deepdiff < 8.0.0' # version 8.0.0 depends on numpy, avoid it
 
-  - when: "distro == rhel-8 or distro == centos-8 or distro == centos-stream-8"
+  - when: >
+      distro == rhel-8 or distro == centos-8 or distro == centos-stream-8 or
+      distro == rhel-9 or distro == centos-9 or distro == centos-stream-9
     because: "packit doesn't support EL 8"
     enabled: false

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -710,3 +710,21 @@ def test_reload(specfile_factory, spec_minimal, spec_traditional, remove_spec):
         after_reload = spec
 
     assert str(before_reload) != str(after_reload)
+
+
+def test_save_after_inode_change(specfile_factory, spec_minimal):
+    spec = specfile_factory(spec_minimal)
+    if spec.path is None:
+        return
+    inode = spec_minimal.stat().st_ino
+    content = spec_minimal.read_bytes()
+    spec_minimal.unlink()
+    spec_minimal.write_bytes(content)
+    assert spec_minimal.stat().st_ino != inode
+    spec.version = "0.2"
+    spec.save()
+    assert all(
+        line.endswith("0.2")
+        for line in spec_minimal.read_text().splitlines()
+        if line.startswith("Version:")
+    )


### PR DESCRIPTION
The underlying file could have been deleted or replaced and its inode may be different, reopening it just before writing should ensure the content is written where it's supposed to.