### PR TITLE
Use latest version of the create-pull-request

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,7 +27,7 @@ jobs:
           prerelease_suffix_pattern: "([.\\-_]?)(a(lpha)?|b(eta)?|r?c|pre(view)?)([.\\-_]?\\d+)?"
           prerelease_suffix_macro: prerelease
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           labels: release
           commit-message: Release ${{ inputs.version }}


### PR DESCRIPTION
Version 4 is failing to label the PR as "release".
https://github.com/packit/specfile/actions/runs/15063508833

I am not sure if this will work, I can try and close later the opened PR.