### PR TITLE
Fix FutureWarning: split() requires a non-empty pattern match

### DIFF
--- a/specfile/value_parser.py
+++ b/specfile/value_parser.py
@@ -74,7 +74,7 @@ class MacroSubstitution(Node):
     """Node representing macro substitution, e.g. _%version_."""
 
     def __init__(self, body: str) -> None:
-        tokens = re.split(r"^([?!]*)", body, maxsplit=1)
+        tokens = re.split(r"^([?!]+)", body, maxsplit=1)
         if len(tokens) == 1:
             self.prefix, self.name = "", tokens[0]
         else:
@@ -97,7 +97,7 @@ class EnclosedMacroSubstitution(Node):
     """Node representing macro substitution enclosed in brackets, e.g. _%{?dist}_."""
 
     def __init__(self, body: str) -> None:
-        tokens = re.split(r"^([?!]*)", body, maxsplit=1)
+        tokens = re.split(r"^([?!]+)", body, maxsplit=1)
         if len(tokens) == 1:
             self.prefix, rest = "", tokens[0]
         else:
@@ -129,7 +129,7 @@ class ConditionalMacroExpansion(Node):
     """Node representing conditional macro expansion, e.g. _%{?prerel:0.}_."""
 
     def __init__(self, condition: str, body: List[Node]) -> None:
-        tokens = re.split(r"^([?!]*)", condition, maxsplit=1)
+        tokens = re.split(r"^([?!]+)", condition, maxsplit=1)
         if len(tokens) == 1:
             self.prefix, self.name = "", tokens[0]
         else:
@@ -271,7 +271,7 @@ class ValueParser:
             elif value[start + 1] == "{":
                 if ":" in value[start:end]:
                     condition, body = value[start + 2 : end - 1].split(":", maxsplit=1)
-                    tokens = re.split(r"^([?!]*)", condition, maxsplit=1)
+                    tokens = re.split(r"^([?!]+)", condition, maxsplit=1)
                     prefix = tokens[0 if len(tokens) == 1 else 1]
                     if "?" in prefix:
                         result.append(


### PR DESCRIPTION
These warnings are emitted with Python 3.6.8 (and probably other versions as well).

Fixes `FutureWarning: split() requires a non-empty pattern match`

This can be easily reproduced with the below:

```python
import sys
from specfile import Specfile

specfile = Specfile(sys.argv[1])
with specfile as spec:
    print (spec.expanded_release)
```

Sample stacktrace:
```
Traceback (most recent call last):
  File "/tmp/3.py", line 11, in <module>
    print (spec.expanded_release)
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/specfile.py", line 770, in expanded_release
    return self.expand(self.release, extra_macros=[("dist", "")])
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/specfile.py", line 761, in release
    return self._split_raw_release(self.raw_release)[0]
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/specfile.py", line 667, in getter
    with self.tags() as tags:
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/context_management.py", line 134, in __call__
    self.values[key] = next(self.generators[key])
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/specfile.py", line 393, in tags
    tags = Tags.parse(section, context=self)
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/tags.py", line 514, in parse
    line, prefix, suffix = split_conditional_macro_expansion(line)
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/utils.py", line 315, in split_conditional_macro_expansion
    nodes = ValueParser.parse(value)
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/value_parser.py", line 278, in parse
    ConditionalMacroExpansion(condition, cls.parse(body))
  File "/home/jesse/.local/lib/python3.6/site-packages/specfile/value_parser.py", line 132, in __init__
    tokens = re.split(r"^([?!]*)", condition, maxsplit=1)
  File "/usr/lib64/python3.6/re.py", line 212, in split
    return _compile(pattern, flags).split(string, maxsplit)
```

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
