### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 # 0.30.0
 
-- Fixed an exception that occured when accessing the `Specfile.has_autochangelog` property while having unparseable lines (e.g. lines ending with unescaped `%`) in `%changelog`. (#387)
+- Fixed an exception that occurred when accessing the `Specfile.has_autochangelog` property while having unparsable lines (e.g. lines ending with unescaped `%`) in `%changelog`. (#387)
 
 # 0.29.0
 
@@ -85,7 +85,7 @@
 
 # 0.28.2
 
-- Handling of trailing newlines in the macro defintions has been improved. (#361)
+- Handling of trailing newlines in the macro definitions has been improved. (#361)
 
 # 0.28.1
 
@@ -184,7 +184,7 @@
 
 # 0.13.2
 
-- Fixed infinite loop that occured when section options were followed by whitespace. (#197)
+- Fixed infinite loop that occurred when section options were followed by whitespace. (#197)
 
 # 0.13.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Main focus is on modifying existing spec files, any change should result in a mi
 
 ## Installation
 
-The library is packaged for Fedora, EPEL 9 and EPEL 8 and you can simply instal it with dnf:
+The library is packaged for Fedora, EPEL 9 and EPEL 8 and you can simply install it with dnf:
 
 ```bash
 dnf install python3-specfile

--- a/specfile/exceptions.py
+++ b/specfile/exceptions.py
@@ -28,7 +28,7 @@ class MacroRemovalException(SpecfileException):
 
 
 class OptionsException(SpecfileException):
-    """Unparseable option string."""
+    """Unparsable option string."""
 
 
 class UnterminatedMacroException(SpecfileException):

--- a/specfile/macro_definitions.py
+++ b/specfile/macro_definitions.py
@@ -253,7 +253,7 @@ class MacroDefinitions(UserList[MacroDefinition]):
     def find(self, name: str, position: Optional[int] = None) -> int:
         """
         Finds a macro definition with the specified name. If position is not specified,
-        returns the first valid matching macro definiton. If there is no such macro
+        returns the first valid matching macro definition. If there is no such macro
         definition, returns the first match, if any. If position is specified and there is
         a matching macro definition at that position, it is returned, otherwise
         `ValueError` is raised.
@@ -287,7 +287,7 @@ class MacroDefinitions(UserList[MacroDefinition]):
         cls, lines: Union[List[str], List[Tuple[str, bool]]]
     ) -> "MacroDefinitions":
         """
-        Parses given lines into macro defintions.
+        Parses given lines into macro definitions.
 
         Args:
             lines: Lines to parse.
@@ -379,7 +379,7 @@ class MacroDefinitions(UserList[MacroDefinition]):
         context: Optional["Specfile"] = None,
     ) -> "MacroDefinitions":
         """
-        Parses given lines into macro defintions.
+        Parses given lines into macro definitions.
 
         Args:
             lines: Lines to parse.

--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -561,7 +561,7 @@ class Specfile:
                     ):
                         return True
             except UnterminatedMacroException:
-                # ignore unparseable lines
+                # ignore unparsable lines
                 continue
         return False
 

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 def get_tag_name_regex(name: str) -> str:
-    """Contructs regex corresponding to the specified tag name."""
+    """Constructs regex corresponding to the specified tag name."""
     regex = re.escape(name)
     if name in TAGS_WITH_ARG:
         regex += r"(?:\s*\(\s*[^\s)]*\s*\))?"

--- a/tests/unit/test_macro_definitions.py
+++ b/tests/unit/test_macro_definitions.py
@@ -108,7 +108,7 @@ def test_parse():
             "",
             "%define example() %{expand:",
             "This an example of a macro definition with body ",
-            "spawning across mutiple lines}",
+            "spawning across multiple lines}",
         ]
     )
     assert macro_definitions[0].name == "gitdate"
@@ -141,7 +141,7 @@ def test_parse():
     assert macro_definitions[-1].body == (
         "%{expand:\n"
         "This an example of a macro definition with body \n"
-        "spawning across mutiple lines}"
+        "spawning across multiple lines}"
     )
 
 
@@ -231,7 +231,7 @@ def test_get_raw_data():
                 "example()",
                 "%{expand:\n"
                 "This an example of a macro definition with body \n"
-                "spawning across mutiple lines}",
+                "spawning across multiple lines}",
                 False,
                 False,
                 CommentOutStyle.DNL,
@@ -269,7 +269,7 @@ def test_get_raw_data():
         "",
         "%define example() %{expand:",
         "This an example of a macro definition with body ",
-        "spawning across mutiple lines}",
+        "spawning across multiple lines}",
         "%global trailing_newline \\",
         "body with trailing newline \\",
         "",


### PR DESCRIPTION
Fix typos in docs and comments.

May I also recommend the use of https://github.com/crate-ci/typos/blob/master/docs/pre-commit.md and https://github.com/crate-ci/typos/blob/master/docs/github-action.md to prevent future occurrences? :)
Happy to submit a pull for these if you'd like.