### PR TITLE
Introduced `typos` pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,3 +84,8 @@ repos:
           - LICENSE_HEADER.txt
           - --comment-style
           - "#"
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.36.2
+    hooks:
+      - id: typos
+        args: [--config, _typos.toml]

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default.ignore_headers]
+extend-ignore-re = [
+    "From:.*=\\?UTF-8\\?q\\?.*",  # Ignore encoded email headers
+]

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,4 @@
-[default.ignore_headers]
+[default]
 extend-ignore-re = [
     "From:.*=\\?UTF-8\\?q\\?.*",  # Ignore encoded email headers
 ]

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,3 +2,6 @@
 extend-ignore-re = [
     "From:.*=\\?UTF-8\\?q\\?.*",  # Ignore encoded email headers
 ]
+
+# Allow these as valid words
+extend-words = { SOURCEN = "SOURCEN" }


### PR DESCRIPTION
_typos.toml is used to discard false positives in email headers:

```
error: `Forr` should be `For`
--> tests/data/spec_no_trailing_newline/patch0.patch:2:26 |
2 | From: =?UTF-8?q?Nikola=20Forr=C3=B3?= <nforro@redhat.com>
|                          ^^^^
```

On the subject of pre-commit hooks, might I suggest removing https://github.com/pre-commit/mirrors-prettier?
pre-commit/mirrors-prettier was actually archived back in Apr 11, 2024.
Further, on my Rocky8 machine, with both Python 3.9 and 3.12, it kept on failing to retrieve the nodejs tar it claimed to need:

```python
$ git commit -a
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/python3.12', '-mnodeenv', '--prebuilt', '--clean-src', '/home/jesse/.cache/pre-commit/repo1a7gxoya/node_env-default')
return code: 1
stdout: (none)
stderr:
     * Install prebuilt node (24.8.0) .Incomplete read while reading from https://nodejs.org/download/release/v24.8.0/node-v24.8.0-linux-x64.tar.gz - IncompleteRead(54483458 bytes read, 4401371 more expected)
    Incomplete read while reading from https://nodejs.org/download/release/v24.8.0/node-v24.8.0-linux-x64.tar.gz - IncompleteRead(54417858 bytes read, 4466971 more expected)
    Incomplete read while reading from https://nodejs.org/download/release/v24.8.0/node-v24.8.0-linux-x64.tar.gz - IncompleteRead(56590530 bytes read, 2294299 more expected)
    
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 1548, in <module>
        main()
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 1130, in main
        create_environment(env_dir, args)
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 1006, in create_environment
        install_node(env_dir, src_dir, args)
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 763, in install_node
        install_node_wrapped(env_dir, src_dir, args)
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 786, in install_node_wrapped
        download_node_src(node_url, src_dir, args)
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 618, in download_node_src
        dl_contents = _download_node_file(node_url)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 610, in _download_node_file
        raise e
      File "/home/jesse/.local/lib/python3.12/site-packages/nodeenv.py", line 602, in _download_node_file
        return io.BytesIO(urlopen(node_url).read())
                          ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.12/http/client.py", line 495, in read
        s = self._safe_read(self.length)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.12/http/client.py", line 644, in _safe_read
        raise IncompleteRead(data, amt-len(data))
    http.client.IncompleteRead: IncompleteRead(56590530 bytes read, 2294299 more expected)
```

On my Debian GNU/Linux 13 (trixie) machine:
```python
$ python --version
Python 3.13.5
$ git commit -a
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/python3', '-mnodeenv', '--prebuilt', '--clean-src', '/home/jesse/.cache/pre-commit/repojzxdfadf/node_env-default')
return code: 1
stdout: (none)
stderr:
    /usr/lib/python3/dist-packages/nodeenv.py:759: SyntaxWarning: invalid escape sequence '\d'
      VERSION_RE = re.compile('\d+\.\d+\.\d+')
    /usr/lib/python3/dist-packages/nodeenv.py:960: SyntaxWarning: invalid escape sequence '\.'
      local re="[a-zA-Z0-9\.\-]+@[0-9]+\.[0-9]+\.[0-9]+([\+\-][a-zA-Z0-9\.\-]+)*"
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/usr/lib/python3/dist-packages/nodeenv.py", line 24, in <module>
        import pipes
    ModuleNotFoundError: No module named 'pipes'
```

Considering that this code base is basically pure Python and we use:
```yaml
  - repo: https://github.com/psf/black
    rev: 25.1.0
    hooks:
      - id: black
```

I'm not sure what value `pre-commit/mirrors-prettier` actually adds but if there's something it checks the other hooks do not address, I'd recommend finding a maintained alternative. 
