### PR TITLE
Try to prevent sideeffects during macro expansion

### DIFF
--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -114,3 +114,20 @@ def test_macros_define():
 def test_macros_reinit():
     Macros.reinit(MacroLevel.BUILTIN)
     assert all(m.level == MacroLevel.BUILTIN for m in Macros.dump())
+
+
+@pytest.mark.xfail(
+    rpm.__version__ <= "4.16.1.3",
+    reason="rpm <= 4.16.1.3 treats builtin macros specially and overriding them has no effect",
+)
+def test_macros_sideeffects():
+    rpm.reloadConfig()
+    rpm.addMacro("with_feature", "1")
+    assert rpm.expandMacro("%with_feature") == "1"
+    Macros.expand("%{expand:%global with_feature 0}", safe=False)
+    assert rpm.expandMacro("%with_feature") == "0"
+    rpm.reloadConfig()
+    rpm.addMacro("with_feature", "1")
+    assert rpm.expandMacro("%with_feature") == "1"
+    Macros.expand("%{expand:%global with_feature 0}", safe=True)
+    assert rpm.expandMacro("%with_feature") == "1"


### PR DESCRIPTION
Macro expansion can have sideeffects and modify other macros, which becomes a problem when the spec file is processed line by line to determine line validity. Even lines in false condition branches are expanded, and if the expansion has sideeffects it can affect further processing and condition evaluation.

Try to prevent that by temporarily overriding macros that can affect other macros, making them noop during expansion.

Unfortunately overriding doesn't work on EL9 and EL8 where RPM behaves differently.

Fixes https://github.com/packit/specfile/issues/498.