### PR TITLE
changelog: ignore entries with wrong day padding

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -641,9 +641,13 @@ class Specfile:
                     elif email is not None:
                         author += f" <{email}>"
                     if changelog:
-                        # try to preserve padding of day of month
+                        # compute day of month padding from the longest valid entry
+                        # incorrect padding is stripped; invalid entries are ignored
                         padding = max(
-                            (e.day_of_month_padding for e in reversed(changelog)),
+                            (
+                                e.sanitized_day_of_month_padding
+                                for e in reversed(changelog)
+                            ),
                             key=len,
                         )
                     else:

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -92,12 +92,17 @@ def test_entry_has_extended_timestamp(header, extended):
         ),
         (
             "* Mon Oct  18 12:34:45 CEST 2021 Nikola Forró <nforro@redhat.com> - 0.2-1",
-            " ",
+            "",  # Invalid: double-digit day with space padding, returns ""
         ),
+        (
+            "* Mon Dec  11 2006 Author <email> - 1.0",
+            "",
+        ),  # Invalid: space before double-digit
+        ("* Invalid header", ""),  # Invalid: unparsable
     ],
 )
 def test_entry_day_of_month_padding(header, padding):
-    assert ChangelogEntry(header, [""]).day_of_month_padding == padding
+    assert ChangelogEntry(header, [""]).sanitized_day_of_month_padding == padding
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This first version of this PR was completely implemented by Claude Code and [Ambient Code](https://github.com/ambient-code/workflows).

After Nikola's amazing review, I fixed the problems myself, especially tinkering with padding fixups and updating the regex that parses day of month to properly account for double-digit days (and don't stop at the first digit - thanks Claude for that one).

Fixes #216 

RELEASE NOTES BEGIN

Changelog entries that have incorrect padding set for a day of a month are now fixed if possible or ignored.

RELEASE NOTES END
