### PR TITLE
Account for circular expansion of tags

### DIFF
--- a/specfile/specfile.py
+++ b/specfile/specfile.py
@@ -637,8 +637,12 @@ class Specfile:
                         except AttributeError:
                             evr = ""
                         evr += f"{tags.version.expanded_value}-"
+                        release_value = tags.release.value
+                        self.expand(release_value, extra_macros=[("dist", "")])
+                        rpm.delMacro("release")
                         evr += self.expand(
-                            tags.release.value, extra_macros=[("dist", "")]
+                            release_value,
+                            skip_parsing=True,
                         )
                 with self.changelog(section) as changelog:
                     if changelog is None:
@@ -799,7 +803,10 @@ class Specfile:
     @property
     def expanded_release(self) -> str:
         """Release string without the dist suffix with macros expanded."""
-        return self.expand(self.release, extra_macros=[("dist", "")])
+        release = self.release
+        self.expand(release, extra_macros=[("dist", "")])
+        rpm.delMacro("release")
+        return self.expand(release, skip_parsing=True)
 
     def set_version_and_release(self, version: str, release: str = "1") -> None:
         """

--- a/specfile/tags.py
+++ b/specfile/tags.py
@@ -16,6 +16,8 @@ from typing import (
     overload,
 )
 
+import rpm
+
 from specfile.conditions import process_conditions
 from specfile.constants import TAG_NAMES, TAGS_WITH_ARG
 from specfile.formatter import formatted
@@ -284,7 +286,20 @@ class Tag:
     def expanded_value(self) -> Optional[str]:
         """Value of the tag after expanding macros."""
         if self._context:
-            return self._context.expand(self.value)
+            # Ensure the macro context is up-to-date
+            self._context.expand("%{nil}")
+            # After parsing, RPM redefines tag macros (e.g. %{release}) to the
+            # expanded tag value, which can cause circular expansion when the
+            # tag value references the same macro indirectly. Pop RPM's
+            # definition to expose the user's original definition underneath.
+            rpm.delMacro(self.name.lower())
+            result = self._context.expand(self.value, skip_parsing=True)
+            # delMacro left the macro stack dirty, invalidate the parse cache
+            # so the next _parse call re-parses and restores tag macros
+            from specfile.spec_parser import SpecParser
+
+            SpecParser._last_parse_hash = None
+            return result
         return Macros.expand(self.value)
 
     def get_position(self, container: "Tags") -> int:

--- a/tests/integration/test_specfile.py
+++ b/tests/integration/test_specfile.py
@@ -10,6 +10,7 @@ from flexmock import flexmock
 
 import specfile.specfile
 from specfile.exceptions import RPMException, SpecfileException
+from specfile.macro_definitions import CommentOutStyle, MacroDefinition
 from specfile.prep import AutopatchMacro, AutosetupMacro, PatchMacro, SetupMacro
 from specfile.sections import Section
 from specfile.specfile import Specfile, SpecParser
@@ -591,14 +592,14 @@ def test_parse_if_necessary(specfile_factory, spec_macros):
     spec2 = copy.deepcopy(spec1)
     flexmock(SpecParser).should_call("_do_parse").never()
     assert spec1.expanded_name == "test"
-    flexmock(SpecParser).should_call("_do_parse").once()
+    flexmock(SpecParser).should_call("_do_parse").twice()
     assert spec2.expanded_name == "test"
     assert spec2.expanded_version == "0.1.2~rc2"
-    flexmock(SpecParser).should_call("_do_parse").once()
+    flexmock(SpecParser).should_call("_do_parse").twice()
     assert spec1.expanded_version == "0.1.2~rc2"
     with spec1.macro_definitions() as md:
         md[0].body = "28"
-    flexmock(SpecParser).should_call("_do_parse").once()
+    flexmock(SpecParser).should_call("_do_parse").twice()
     assert spec1.expanded_name == "test"
     assert spec1.expanded_version == "28.1.2~rc2"
     flexmock(SpecParser).should_receive("id").and_return(12345)
@@ -776,3 +777,29 @@ def test_sanitize(specfile_factory, spec_unsafe):
     ]:
         assert spec1.expand(expr) != ""
         assert spec2.expand(expr) == ""
+
+
+def test_circular_expansion(specfile_factory, spec_macros):
+    spec = specfile_factory(spec_macros)
+    with spec.macro_definitions() as md:
+        md.release.body = "1"
+        md.insert(
+            md.find("release") + 1,
+            MacroDefinition(
+                "release_string",
+                "%{release}%{?dist}",
+                False,
+                False,
+                CommentOutStyle.DNL,
+                ("", " ", " ", ""),
+            ),
+        )
+    with spec.tags() as tags:
+        tags.release.value = "%{release_string}"
+    dist = spec.expand("%{?dist}")
+    with spec.tags() as tags:
+        assert tags.release.expanded_value == f"1{dist}"
+        assert tags.version.expanded_value == "0.1.2~rc2"
+    assert spec.expanded_release == "1"
+    with spec.sources() as sources:
+        assert "0.1.2~rc2" in sources[0].expanded_location


### PR DESCRIPTION
RELEASE NOTES BEGIN

Fixed an issue where the value of a tag could have been incorrectly expanded if the spec file contained a macro definition shadowing the tag name, e.g.:

```
%global release 12
%global release_string %{release}%{?dist}

Release: %{release_string}
```

In this case, with `dist` being `.fc44`, `Specfile.expanded_release` returned `12.fc44.fc44` instead of `12.fc44`.

RELEASE NOTES END
